### PR TITLE
FEATURE: Skip unknown properties when mapping events

### DIFF
--- a/Classes/EventStore/EventStream.php
+++ b/Classes/EventStore/EventStream.php
@@ -53,7 +53,8 @@ final class EventStream implements \Iterator
     {
         $configuration = new PropertyMappingConfiguration();
         $configuration->allowAllProperties();
-        $configuration->forProperty('*')->allowAllProperties();
+        $configuration->skipUnknownProperties();
+        $configuration->forProperty('*')->allowAllProperties()->skipUnknownProperties();
 
         /** @var RawEvent $rawEvent */
         $rawEvent = $this->streamIterator->current();


### PR DESCRIPTION
This change configures the property mapper to ignore unknown
properties from the source (serialized event) when mapping
them to the event class.

It only will show an effect in combination with  a new core feature:
https://github.com/neos/flow-development-collection/pull/883

Addresses #94