### PR TITLE
TASK: Throw exception on duplicate event mapping from ProvidesEventTypeInterface

### DIFF
--- a/Classes/Event/EventTypeResolver.php
+++ b/Classes/Event/EventTypeResolver.php
@@ -146,11 +146,10 @@ class EventTypeResolver
             if (is_subclass_of($eventClassName, ProvidesEventTypeInterface::class)) {
                 $eventTypeIdentifier = $eventClassName::getEventType();
             } else {
-                $type = $buildEventType($eventClassName);
                 $eventTypeIdentifier = $buildEventType($eventClassName);
-                if (in_array($type, $mapping)) {
-                    throw new Exception(sprintf('Duplicate event type "%s"', $type), 1474710799);
-                }
+            }
+            if (in_array($eventTypeIdentifier, $mapping)) {
+                throw new Exception(sprintf('Duplicate event type "%s" mapped from "%s".', $eventTypeIdentifier, $eventClassName), 1474710799);
             }
             $mapping[$eventClassName] = $eventTypeIdentifier;
         }


### PR DESCRIPTION
Implementations of `ProvidesEventTypeInterface` might also be prone to duplicate event types