### PR TITLE
FEATURE: Support for multiple Event Store backends

### DIFF
--- a/Classes/Command/EventStoreCommandController.php
+++ b/Classes/Command/EventStoreCommandController.php
@@ -11,9 +11,11 @@ namespace Neos\EventSourcing\Command;
  * source code.
  */
 
-use Doctrine\DBAL\Exception\ConnectionException;
-use Neos\EventSourcing\EventStore\Storage\Doctrine\Factory\ConnectionFactory;
-use Neos\EventSourcing\EventStore\Storage\Doctrine\Schema\EventStoreSchema;
+use Neos\Error\Messages\Error;
+use Neos\Error\Messages\Notice;
+use Neos\Error\Messages\Result;
+use Neos\Error\Messages\Warning;
+use Neos\EventSourcing\EventStore\EventStoreManager;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\CommandController;
 
@@ -25,10 +27,10 @@ use Neos\Flow\Cli\CommandController;
 class EventStoreCommandController extends CommandController
 {
     /**
-     * @var ConnectionFactory
+     * @var EventStoreManager
      * @Flow\Inject
      */
-    protected $connectionFactory;
+    protected $eventStoreManager;
 
     /**
      * @var array
@@ -37,118 +39,102 @@ class EventStoreCommandController extends CommandController
     protected $configuration;
 
     /**
-     * Create Event Store database tables
+     * Sets up the specified Event Store backend
      *
-     * This command creates the necessary database tables for the Event Store. It uses the Doctrine connection
-     * parameters which were defined for Flow.
+     * This command initializes the given Event Store adapters (i.e. creates required tables if it is database
+     * driven and/or validates the configuration against the actual backend)
      *
+     * @param string $eventStore The identifier of the Event Store to set up
      * @return void
      */
-    public function createSchemaCommand()
+    public function setupCommand($eventStore)
     {
-        $this->outputLine('Creating Event Store database tables in database "%s" on host %s connecting with user "%s" ...', [ $this->configuration['backendOptions']['dbname'], $this->configuration['backendOptions']['host'], $this->configuration['backendOptions']['user']]);
-        try {
-            $connection = $this->connectionFactory->get();
-
-            if ($connection->getSchemaManager()->tablesExist([$this->connectionFactory->getStreamTableName()])) {
-                $this->outputLine('The table %s already exists, not changing anything.', [$this->connectionFactory->getStreamTableName()]);
-                $this->quit(1);
-                exit;
-            }
-
-            $schema = $connection->getSchemaManager()->createSchema();
-            $toSchema = clone $schema;
-
-            EventStoreSchema::createStream($toSchema, $this->connectionFactory->getStreamTableName());
-
-            $connection->beginTransaction();
-            $statements = $schema->getMigrateToSql($toSchema, $connection->getDatabasePlatform());
-            foreach ($statements as $statement) {
-                $this->outputLine('<info>++</info> %s', [$statement]);
-                $connection->exec($statement);
-            }
-            $connection->commit();
-
-            $this->outputLine();
-        } catch (ConnectionException $exception) {
-            $this->outputLine('<error>Connection failed</error>');
-            $this->outputLine('%s', [ $exception->getMessage() ]);
+        $eventStores = $this->eventStoreManager->getAllEventStores();
+        if (!isset($eventStores[$eventStore])) {
+            $this->outputLine('<error>There is no Event Store "%s" configured</error>', [$eventStore]);
             $this->quit(1);
         }
+        $this->outputLine('Setting up Event Store "%s"', [$eventStore]);
+        $result = $eventStores[$eventStore]->setup();
+        $this->renderResult($result);
     }
 
     /**
-     * Drop Event Store database tables
+     * Sets up all configured Event Store backends
      *
-     * This command <b>deletes all</b> Event Store related database tables! It uses the Doctrine connection
-     * parameters which were defined for Flow.
+     * This command initializes all configured Event Store adapters (i.e. creates required tables for database
+     * driven storages and/or validates the configuration against the actual backends)
      *
      * @return void
      */
-    public function dropSchemaCommand()
+    public function setupAllCommand()
     {
-        $this->outputLine('<error>Warning</error>');
-        $this->outputLine('You are about to drop all Event Store related tables in database "%s" on host %s.', [ $this->configuration['backendOptions']['dbname'], $this->configuration['backendOptions']['host']]);
-        if (!$this->output->askConfirmation('Are you sure? ', false)) {
-            $this->outputLine('Aborted.');
-            $this->quit(0);
-        }
-
-        try {
-            $connection = $this->connectionFactory->get();
-
-            $schema = $connection->getSchemaManager()->createSchema();
-            $toSchema = clone $schema;
-
-            if ($schema->hasTable($this->connectionFactory->getStreamTableName())) {
-                EventStoreSchema::drop($toSchema, $this->connectionFactory->getStreamTableName());
-            }
-
-            $connection->beginTransaction();
-            $statements = $schema->getMigrateToSql($toSchema, $connection->getDatabasePlatform());
-            foreach ($statements as $statement) {
-                $this->outputLine('<info>++</info> %s', [$statement]);
-                $connection->exec($statement);
-            }
-            $connection->commit();
-
+        $eventStores = $this->eventStoreManager->getAllEventStores();
+        $this->outputLine('Setting up <b>%d</b> Event Store backend(s):', [count($eventStores)]);
+        foreach ($eventStores as $eventStoreIdentifier => $eventStore) {
             $this->outputLine();
-        } catch (ConnectionException $exception) {
-            $this->outputLine('<error>Connection failed</error>');
-            $this->outputLine('%s', [ $exception->getMessage() ]);
-            $this->quit(1);
+            $this->outputLine('<b>Event Store "%s":</b>', [$eventStoreIdentifier]);
+            $this->outputLine(str_repeat('-', $this->output->getMaximumLineLength()));
+            $result = $eventStore->setup();
+            $this->renderResult($result);
         }
     }
 
     /**
      * Display Event Store connection status
      *
-     * This command displays some basic status about the connection of the configured Event Store.
+     * This command displays some basic status about the connection of the configured Event Stores.
      *
      * @return void
      */
     public function statusCommand()
     {
-        try {
-            $connection = $this->connectionFactory->get();
-        } catch (ConnectionException $exception) {
-            $this->outputLine('<error>Connection failed</error>');
-            $this->outputLine('%s', [ $exception->getMessage() ]);
-            $this->quit(1);
-            exit;
+        $eventStores = $this->eventStoreManager->getAllEventStores();
+        $this->outputLine('Displaying status information for <b>%d</b> Event Store backend(s):', [count($eventStores)]);
+
+        foreach ($eventStores as $eventStoreIdentifier => $eventStore) {
+            $this->outputLine();
+            $this->outputLine('<b>Event Store "%s"</b>', [$eventStoreIdentifier]);
+            $this->outputLine(str_repeat('-', $this->output->getMaximumLineLength()));
+
+            $this->renderResult($eventStore->getStatus());
+        }
+    }
+
+    /**
+     * Outputs the given Result object in a human-readable way
+     *
+     * @param Result $result
+     */
+    private function renderResult(Result $result)
+    {
+        if ($result->hasNotices()) {
+            /** @var Notice $notice */
+            foreach ($result->getNotices() as $notice) {
+                if ($notice->getTitle() !== null) {
+                    $this->outputLine('<b>%s</b>: %s', [$notice->getTitle(), $notice->render()]);
+                } else {
+                    $this->outputLine($notice->render());
+                }
+            }
         }
 
-        $tableName = $this->connectionFactory->getStreamTableName();
-        $tableExists = ($connection->getSchemaManager()->tablesExist([$tableName]));
-
-        $this->outputLine('<success>Connection was successful</success>');
-        $this->output->outputTable([
-            ['Host', $connection->getHost()],
-            ['Port', $connection->getPort()],
-            ['Database', $connection->getDatabase()],
-            ['Username', $connection->getUsername()],
-            ['Driver', $connection->getDriver()->getName()],
-            ['Table', $tableName . ($tableExists ? ' (<success>exists</success>)' : ' (<error>missing</error>)')]
-        ]);
+        if ($result->hasErrors()) {
+            /** @var Error $error */
+            foreach ($result->getErrors() as $error) {
+                $this->outputLine('<error>ERROR: %s</error>', [$error->render()]);
+            }
+        } elseif ($result->hasWarnings()) {
+            /** @var Warning $warning */
+            foreach ($result->getWarnings() as $warning) {
+                if ($warning->getTitle() !== null) {
+                    $this->outputLine('<b>%s</b>: <em>%s !!!</em>', [$warning->getTitle(), $warning->render()]);
+                } else {
+                    $this->outputLine('<em>%s !!!</em>', [$warning->render()]);
+                }
+            }
+        } else {
+            $this->outputLine('<success>SUCCESS</success>');
+        }
     }
 }

--- a/Classes/EventListener/EventListenerLocator.php
+++ b/Classes/EventListener/EventListenerLocator.php
@@ -43,20 +43,13 @@ class EventListenerLocator
     private $eventClassNamesAndListeners = [];
 
     /**
-     * @var EventStore
-     */
-    private $eventStore;
-
-    /**
      * @param ObjectManagerInterface $objectManager
      * @param EventTypeResolver $eventTypeService
-     * @param EventStore $eventStore
      */
-    public function __construct(ObjectManagerInterface $objectManager, EventTypeResolver $eventTypeService, EventStore $eventStore)
+    public function __construct(ObjectManagerInterface $objectManager, EventTypeResolver $eventTypeService)
     {
         $this->objectManager = $objectManager;
         $this->eventTypeService = $eventTypeService;
-        $this->eventStore = $eventStore;
     }
 
     /**

--- a/Classes/EventStore/AbstractEventSourcedRepository.php
+++ b/Classes/EventStore/AbstractEventSourcedRepository.php
@@ -24,9 +24,9 @@ abstract class AbstractEventSourcedRepository implements RepositoryInterface
 {
     /**
      * @Flow\Inject
-     * @var EventStore
+     * @var EventStoreManager
      */
-    protected $eventStore;
+    protected $eventStoreManager;
 
     /**
      * @Flow\Inject
@@ -63,7 +63,8 @@ abstract class AbstractEventSourcedRepository implements RepositoryInterface
     public function get(string $identifier)
     {
         $streamName = $this->streamNameResolver->getStreamNameForAggregateTypeAndIdentifier($this->aggregateClassName, $identifier);
-        $eventStream = $this->eventStore->get(new StreamNameFilter($streamName));
+        $eventStore = $this->eventStoreManager->getEventStoreForStreamName($streamName);
+        $eventStream = $eventStore->get(new StreamNameFilter($streamName));
 
         if (!class_exists($this->aggregateClassName)) {
             throw new AggregateRootNotFoundException(sprintf("Could not reconstitute the aggregate root %s because its class '%s' does not exist.", $identifier, $this->aggregateClassName), 1474454928115);

--- a/Classes/EventStore/EventStore.php
+++ b/Classes/EventStore/EventStore.php
@@ -11,20 +11,27 @@ namespace Neos\EventSourcing\EventStore;
  * source code.
  */
 
+use Neos\Error\Messages\Result;
 use Neos\EventSourcing\EventStore\Exception\EventStreamNotFoundException;
 use Neos\EventSourcing\EventStore\Storage\EventStorageInterface;
 use Neos\Flow\Annotations as Flow;
 
 /**
- * @Flow\Scope("singleton")
+ * Main API to store and fetch events.
+ *
+ * NOTE: Do not instantiate this class directly but use the EventStoreManager
  */
-class EventStore
+final class EventStore
 {
     /**
      * @var EventStorageInterface
      */
     private $storage;
 
+    /**
+     * @internal Do not instantiate this class directly but use the EventStoreManager
+     * @param EventStorageInterface $storage
+     */
     public function __construct(EventStorageInterface $storage)
     {
         $this->storage = $storage;
@@ -54,5 +61,25 @@ class EventStore
     public function commit(string $streamName, WritableEvents $events, int $expectedVersion = ExpectedVersion::ANY): array
     {
         return $this->storage->commit($streamName, $events, $expectedVersion);
+    }
+
+    /**
+     * Returns the (connection) status of this Event Store, @see EventStorageInterface::getStatus()
+     *
+     * @return Result
+     */
+    public function getStatus()
+    {
+        return $this->storage->getStatus();
+    }
+
+    /**
+     * Sets up this Event Store and returns a status, @see EventStorageInterface::setup()
+     *
+     * @return Result
+     */
+    public function setup()
+    {
+        return $this->storage->setup();
     }
 }

--- a/Classes/EventStore/EventStoreManager.php
+++ b/Classes/EventStore/EventStoreManager.php
@@ -1,0 +1,202 @@
+<?php
+namespace Neos\EventSourcing\EventStore;
+
+/*
+ * This file is part of the Neos.EventStore package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\EventSourcing\EventStore\Exception\StorageConfigurationException;
+use Neos\EventSourcing\EventStore\Storage\EventStorageInterface;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
+
+/**
+ * The Event Store manager is responsible for building and Event Store instances as configured.
+ * Whenever an Event Store is needed, it should be retrieved through this class.
+ *
+ * @Flow\Scope("singleton")
+ */
+final class EventStoreManager
+{
+    /**
+     * @var ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * @var array
+     */
+    private $configuration;
+
+    /**
+     * @var string[]
+     */
+    private $eventStoreIdentifiersPerBoundedContext = null;
+
+    /**
+     * A list of all initialized event stores, indexed by the "Event Store identifier"
+     *
+     * @var EventStore[]
+     */
+    private $initializedEventStores;
+
+    /**
+     * This class is usually not instantiated manually but injected like other singletons
+     * Note: ObjectManager and configuration is constructor-injected in order to ease testing & composition
+     *
+     * @param ObjectManagerInterface $objectManager
+     * @param array $configuration
+     */
+    public function __construct(ObjectManagerInterface $objectManager, array $configuration)
+    {
+        $this->objectManager = $objectManager;
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * Initializes the Event Store adapters as configured
+     * This also validates the Event Store configuration
+     *
+     * @return void
+     * @throws StorageConfigurationException
+     */
+    private function initialize()
+    {
+        if ($this->eventStoreIdentifiersPerBoundedContext !== null) {
+            return;
+        }
+        $this->eventStoreIdentifiersPerBoundedContext = [];
+        foreach ($this->configuration as $eventStoreIdentifier => $eventStoreConfiguration) {
+            if (!isset($eventStoreConfiguration['boundedContexts']) || empty($eventStoreConfiguration['boundedContexts'])) {
+                throw new StorageConfigurationException(sprintf('The Event Store "%s" has no Bounded Context assigned. Please configure some.', $eventStoreIdentifier), 1479213813);
+            }
+            foreach ($eventStoreConfiguration['boundedContexts'] as $boundedContext => $isActive) {
+                if (!$isActive) {
+                    continue;
+                }
+                if (isset($this->eventStoreIdentifiersPerBoundedContext[$boundedContext])) {
+                    throw new StorageConfigurationException(sprintf('The Event Stores "%s" and "%s" are both configured for the Bounded Context "%s" but overlaps are not supported.', $this->eventStoreIdentifiersPerBoundedContext[$boundedContext], $eventStoreIdentifier, $boundedContext), 1492434176);
+                }
+                $this->eventStoreIdentifiersPerBoundedContext[$boundedContext] = $eventStoreIdentifier;
+            }
+        }
+
+        if (!isset($this->eventStoreIdentifiersPerBoundedContext['*'])) {
+            throw new StorageConfigurationException('No Event Store found for fallback Bounded Context "*"', 1479214520);
+        }
+    }
+
+    /**
+     * Retrieves/builds an EventStore instance with the given identifier
+     *
+     * @param string $eventStoreIdentifier The unique Event Store identifier as configured
+     * @return EventStore
+     * @throws \RuntimeException|StorageConfigurationException
+     */
+    public function getEventStore(string $eventStoreIdentifier): EventStore
+    {
+        $this->initialize();
+        if (isset($this->initializedEventStores[$eventStoreIdentifier])) {
+            return $this->initializedEventStores[$eventStoreIdentifier];
+        }
+        if (!isset($this->configuration[$eventStoreIdentifier])) {
+            throw new \RuntimeException(sprintf('No Event Store with the identifier "%s" is configured', $eventStoreIdentifier), 1492610857);
+        }
+        if (!isset($this->configuration[$eventStoreIdentifier]['storage'])) {
+            throw new StorageConfigurationException(sprintf('There is no Storage configured for Event Store "%s"', $eventStoreIdentifier), 1492610902);
+        }
+        $storageClassName = $this->configuration[$eventStoreIdentifier]['storage'];
+        $storageOptions = $this->configuration[$eventStoreIdentifier]['storageOptions'] ?? [];
+
+        /** @noinspection PhpMethodParametersCountMismatchInspection */
+        $storageInstance = $this->objectManager->get($storageClassName, $storageOptions);
+        if (!$storageInstance instanceof EventStorageInterface) {
+            throw new StorageConfigurationException(sprintf('The configured Storage for Event Store "%s" does not implement the EventStorageInterface', $eventStoreIdentifier), 1492610908);
+        }
+        /** @noinspection PhpMethodParametersCountMismatchInspection */
+        $this->initializedEventStores[$eventStoreIdentifier] = $this->objectManager->get(EventStore::class, $storageInstance);
+
+        return $this->initializedEventStores[$eventStoreIdentifier];
+    }
+
+    /**
+     * Retrieves/builds an EventStore instance matching the given stream name
+     *
+     * @param string $streamName The stream name can be any string, but usually it has the format "<Bounded.Context>:<Aggregate>-<Identifier>"
+     * @return EventStore
+     */
+    public function getEventStoreForStreamName(string $streamName): EventStore
+    {
+        $boundedContext = $this->extractBoundedContextFromDesignator($streamName);
+        return $this->getEventStoreForBoundedContext($boundedContext);
+    }
+
+    /**
+     * Retrieves/builds an EventStore instance matching the given event types
+     *
+     * @param string $listenerClassName The fully qualified class name of the EventListener (or Projector)
+     * @return EventStore
+     */
+   public function getEventStoreForEventListener(string $listenerClassName)
+    {
+        $boundedContext = $this->objectManager->getPackageKeyByObjectName($listenerClassName) ?? '';
+        return $this->getEventStoreForBoundedContext($boundedContext);
+    }
+
+    /**
+     * Retrieves/builds an EventStore instance matching the given Bounded Context
+     *
+     * @param string $boundedContext The Bounded Context can be any string, for example a package key like "Some.Package"
+     * @return EventStore
+     */
+    public function getEventStoreForBoundedContext(string $boundedContext): EventStore
+    {
+        $this->initialize();
+        $eventStoreIdentifier = $this->eventStoreIdentifiersPerBoundedContext[$boundedContext] ?? $this->eventStoreIdentifiersPerBoundedContext['*'];
+        return $this->getEventStore($eventStoreIdentifier);
+    }
+
+    /**
+     * Retrieves/builds all configured EventStore instances
+     *
+     * Note: As this method instantiates all configured Event Store adapters it should only be used for monitoring/testing
+     *
+     * @return EventStore[]
+     */
+    public function getAllEventStores(): array
+    {
+        $this->initialize();
+        $eventStores = [];
+        foreach ($this->eventStoreIdentifiersPerBoundedContext as $eventStoreIdentifier) {
+            // Note: getEventStore() will initialize the given Event Store
+            $eventStores[$eventStoreIdentifier] = $this->getEventStore($eventStoreIdentifier);
+        }
+        return $eventStores;
+    }
+
+    /**
+     * Determines the Bounded Context identifier from a fully qualified designator (event type, stream name, ...)
+     * The BC is the substring of the designator before the first colon.
+     * If the designator doesn't contain any colons, the full designator is considered the BC!!
+     *
+     * Examples:
+     *
+     * "Foo:Bar" => "Foo"
+     * "Foo.Bar:Baz:Foos" => "Foo.Bar"
+     * "Foo.Bar" => "Foo.Bar"
+     *
+     * @param string $designator
+     * @return string
+     */
+    private function extractBoundedContextFromDesignator(string $designator): string
+    {
+        $boundedContext = strstr($designator, ':', true);
+        return $boundedContext !== false ? $boundedContext : $designator;
+    }
+}

--- a/Classes/EventStore/EventStoreManager.php
+++ b/Classes/EventStore/EventStoreManager.php
@@ -143,7 +143,7 @@ final class EventStoreManager
      * @param string $listenerClassName The fully qualified class name of the EventListener (or Projector)
      * @return EventStore
      */
-   public function getEventStoreForEventListener(string $listenerClassName)
+    public function getEventStoreForEventListener(string $listenerClassName)
     {
         $boundedContext = $this->objectManager->getPackageKeyByObjectName($listenerClassName) ?? '';
         return $this->getEventStoreForBoundedContext($boundedContext);

--- a/Classes/EventStore/Exception/StorageConfigurationException.php
+++ b/Classes/EventStore/Exception/StorageConfigurationException.php
@@ -1,0 +1,18 @@
+<?php
+namespace Neos\EventSourcing\EventStore\Exception;
+
+/*
+ * This file is part of the Neos.EventStore package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\EventSourcing\RuntimeException;
+
+class StorageConfigurationException extends RuntimeException
+{
+}

--- a/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
+++ b/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
@@ -12,14 +12,20 @@ namespace Neos\EventSourcing\EventStore\Storage\Doctrine;
  */
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\ConnectionException;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Types\Type;
+use Neos\Error\Messages\Error;
+use Neos\Error\Messages\Notice;
+use Neos\Error\Messages\Result;
+use Neos\Error\Messages\Warning;
 use Neos\EventSourcing\Event\EventTypeResolver;
 use Neos\EventSourcing\EventStore\EventStream;
 use Neos\EventSourcing\EventStore\EventStreamFilterInterface;
 use Neos\EventSourcing\EventStore\Exception\ConcurrencyException;
 use Neos\EventSourcing\EventStore\ExpectedVersion;
 use Neos\EventSourcing\EventStore\Storage\Doctrine\Factory\ConnectionFactory;
+use Neos\EventSourcing\EventStore\Storage\Doctrine\Schema\EventStoreSchema;
 use Neos\EventSourcing\EventStore\Storage\EventStorageInterface;
 use Neos\EventSourcing\EventStore\RawEvent;
 use Neos\EventSourcing\EventStore\StreamNameFilter;
@@ -29,10 +35,12 @@ use Neos\Flow\Property\PropertyMapper;
 use Neos\Flow\Utility\Now;
 
 /**
- * Database event storage, for testing purpose
+ * Database event storage adapter
  */
 class DoctrineEventStorage implements EventStorageInterface
 {
+    const DEFAULT_EVENT_TABLE_NAME = 'neos_eventsourcing_eventstore_events';
+
     /**
      * @var ConnectionFactory
      * @Flow\Inject
@@ -62,16 +70,41 @@ class DoctrineEventStorage implements EventStorageInterface
      */
     private $connection;
 
-    protected function initializeObject()
+    /**
+     * @var string
+     */
+    private $eventTableName;
+
+    /**
+     * @var array
+     */
+    private $options;
+
+    /**
+     * @param array $options
+     */
+    public function __construct(array $options)
     {
-        $this->connection = $this->connectionFactory->get();
+        $this->options = $options;
+        $this->eventTableName = $options['eventTableName'] ?? self::DEFAULT_EVENT_TABLE_NAME;
     }
 
+    /**
+     * @return void
+     */
+    public function initializeObject()
+    {
+        $this->connection = $this->connectionFactory->create($this->options);
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function load(EventStreamFilterInterface $filter): EventStream
     {
         $query = $this->connection->createQueryBuilder()
             ->select('*')
-            ->from($this->connectionFactory->getStreamTableName())
+            ->from($this->eventTableName)
             ->orderBy('sequencenumber', 'ASC');
         $this->applyEventStreamFilter($query, $filter);
 
@@ -80,10 +113,7 @@ class DoctrineEventStorage implements EventStorageInterface
     }
 
     /**
-     * @param string $streamName
-     * @param WritableEvents $events
-     * @param int $expectedVersion
-     * @return RawEvent[]
+     * @inheritdoc
      * @throws ConcurrencyException|\Exception
      */
     public function commit(string $streamName, WritableEvents $events, int $expectedVersion = ExpectedVersion::ANY): array
@@ -95,7 +125,7 @@ class DoctrineEventStorage implements EventStorageInterface
         $rawEvents = [];
         foreach ($events as $event) {
             $this->connection->insert(
-                $this->connectionFactory->getStreamTableName(),
+                $this->eventTableName,
                 [
                     'id' => $event->getIdentifier(),
                     'stream' => $streamName,
@@ -125,12 +155,17 @@ class DoctrineEventStorage implements EventStorageInterface
     {
         $query = $this->connection->createQueryBuilder()
             ->select('MAX(version)')
-            ->from($this->connectionFactory->getStreamTableName());
+            ->from($this->eventTableName);
         $this->applyEventStreamFilter($query, $filter);
         $version = $query->execute()->fetchColumn();
         return $version !== null ? (int)$version : -1;
     }
 
+    /**
+     * @param int $actualVersion
+     * @param int $expectedVersion
+     * @throws ConcurrencyException
+     */
     private function verifyExpectedVersion(int $actualVersion, int $expectedVersion)
     {
         if ($expectedVersion === ExpectedVersion::ANY) {
@@ -142,6 +177,10 @@ class DoctrineEventStorage implements EventStorageInterface
         throw new ConcurrencyException(sprintf('Expected version: %s, actual version: %s', $this->renderExpectedVersion($expectedVersion), $this->renderExpectedVersion($actualVersion)), 1477143473);
     }
 
+    /**
+     * @param int $expectedVersion
+     * @return string
+     */
     private function renderExpectedVersion(int $expectedVersion)
     {
         if ($expectedVersion === ExpectedVersion::ANY) {
@@ -153,6 +192,10 @@ class DoctrineEventStorage implements EventStorageInterface
         return (string)$expectedVersion;
     }
 
+    /**
+     * @param QueryBuilder $query
+     * @param EventStreamFilterInterface $filter
+     */
     private function applyEventStreamFilter(QueryBuilder $query, EventStreamFilterInterface $filter)
     {
         if ($filter->hasStreamName()) {
@@ -170,5 +213,63 @@ class DoctrineEventStorage implements EventStorageInterface
             $query->andWhere('sequencenumber >= :minimumSequenceNumber');
             $query->setParameter('minimumSequenceNumber', $filter->getMinimumSequenceNumber());
         }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getStatus()
+    {
+        $result = new Result();
+        try {
+            $tableExists = $this->connection->getSchemaManager()->tablesExist([$this->eventTableName]);
+        } catch (ConnectionException $exception) {
+            $result->addError(new Error($exception->getMessage(), $exception->getCode(), [], 'Connection failed'));
+            return $result;
+        }
+        $result->addNotice(new Notice($this->connection->getHost(), null, [], 'Host'));
+        $result->addNotice(new Notice($this->connection->getPort(), null, [], 'Port'));
+        $result->addNotice(new Notice($this->connection->getDatabase(), null, [], 'Database'));
+        $result->addNotice(new Notice($this->connection->getDriver()->getName(), null, [], 'Driver'));
+        $result->addNotice(new Notice($this->connection->getUsername(), null, [], 'Username'));
+        if ($tableExists) {
+            $result->addNotice(new Notice('%s (exists)', null, [$this->eventTableName], 'Table'));
+        } else {
+            $result->addWarning(new Warning('%s (missing)', null, [$this->eventTableName], 'Table'));
+        }
+        return $result;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setup()
+    {
+        $result = new Result();
+        try {
+            $tableExists = $this->connection->getSchemaManager()->tablesExist([$this->eventTableName]);
+        } catch (ConnectionException $exception) {
+            $result->addError(new Error($exception->getMessage(), $exception->getCode(), [], 'Connection failed'));
+            return $result;
+        }
+        if ($tableExists) {
+            $result->addNotice(new Notice('Table "%s" (already exists)', null, [$this->eventTableName], 'Skipping'));
+            return $result;
+        }
+        $result->addNotice(new Notice('Creating database table "%s" in database "%s" on host %s....', null, [$this->eventTableName, $this->connection->getDatabase(), $this->connection->getHost()]));
+
+        $schema = $this->connection->getSchemaManager()->createSchema();
+        $toSchema = clone $schema;
+
+        EventStoreSchema::createStream($toSchema, $this->eventTableName);
+
+        $this->connection->beginTransaction();
+        $statements = $schema->getMigrateToSql($toSchema, $this->connection->getDatabasePlatform());
+        foreach ($statements as $statement) {
+            $result->addNotice(new Notice('<info>++</info> %s', null, [$statement]));
+            $this->connection->exec($statement);
+        }
+        $this->connection->commit();
+        return $result;
     }
 }

--- a/Classes/EventStore/Storage/Doctrine/Factory/ConnectionFactory.php
+++ b/Classes/EventStore/Storage/Doctrine/Factory/ConnectionFactory.php
@@ -16,52 +16,40 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Types\Type;
 use Neos\Flow\Annotations as Flow;
+use Neos\Utility\Arrays;
 
 /**
- * ConnectionFactory
+ * Factory for Doctrine connections
  *
  * @Flow\Scope("singleton")
  */
 class ConnectionFactory
 {
-    /**
-     * @var array
-     * @Flow\InjectConfiguration(path="EventStore.storage.options")
-     */
-    protected $configuration;
 
     /**
-     * @var Connection
+     * @var @Flow\InjectConfiguration(package="Neos.Flow", path="persistence.backendOptions")
      */
-    protected $connection;
+    protected $defaultFlowDatabaseConfiguration;
 
     /**
+     * @param array $options
      * @return Connection
      */
-    public function get()
+    public function create(array $options)
     {
-        if ($this->connection !== null) {
-            return $this->connection;
-        }
         $config = new Configuration();
-        $connectionParams = $this->configuration['backendOptions'];
-        $this->connection = DriverManager::getConnection($connectionParams, $config);
+        $connectionParams = $options['backendOptions'] ?? [];
+        $connectionParams = Arrays::arrayMergeRecursiveOverrule($this->defaultFlowDatabaseConfiguration, $connectionParams);
 
-        if (isset($this->configuration['mappingTypes']) && is_array($this->configuration['mappingTypes'])) {
-            foreach ($this->configuration['mappingTypes'] as $typeName => $typeConfiguration) {
+        $connection = DriverManager::getConnection($connectionParams, $config);
+
+        if (isset($options['mappingTypes']) && is_array($options['mappingTypes'])) {
+            foreach ($options['mappingTypes'] as $typeName => $typeConfiguration) {
                 Type::addType($typeName, $typeConfiguration['className']);
-                $this->connection->getDatabasePlatform()->registerDoctrineTypeMapping($typeConfiguration['dbType'], $typeName);
+                $connection->getDatabasePlatform()->registerDoctrineTypeMapping($typeConfiguration['dbType'], $typeName);
             }
         }
 
-        return $this->connection;
-    }
-
-    /**
-     * @return string
-     */
-    public function getStreamTableName()
-    {
-        return $this->configuration['eventTableName'];
+        return $connection;
     }
 }

--- a/Classes/EventStore/Storage/EventStorageInterface.php
+++ b/Classes/EventStore/Storage/EventStorageInterface.php
@@ -11,6 +11,7 @@ namespace Neos\EventSourcing\EventStore\Storage;
  * source code.
  */
 
+use Neos\Error\Messages\Result;
 use Neos\EventSourcing\EventStore\EventStream;
 use Neos\EventSourcing\EventStore\EventStreamFilterInterface;
 use Neos\EventSourcing\EventStore\ExpectedVersion;
@@ -18,7 +19,7 @@ use Neos\EventSourcing\EventStore\RawEvent;
 use Neos\EventSourcing\EventStore\WritableEvents;
 
 /**
- * EventStorageInterface
+ * Contract for Event Storage adapters
  */
 interface EventStorageInterface
 {
@@ -35,4 +36,24 @@ interface EventStorageInterface
      * @return RawEvent[]
      */
     public function commit(string $streamName, WritableEvents $events, int $expectedVersion = ExpectedVersion::ANY): array;
+
+    /**
+     * Retrieves the (connection) status of the storage adapter
+     *
+     * If the result contains no errors, the status is considered valid
+     * The result may contain Notices, Warnings and Errors
+     *
+     * @return Result
+     */
+    public function getStatus();
+
+    /**
+     * Sets up the configured storage adapter (i.e. creates required database tables) and validates the configuration
+     *
+     * If the result contains no errors, the setup is considered successful
+     * The result may contain Notices, Warnings and Errors
+     *
+     * @return Result
+     */
+    public function setup();
 }

--- a/Classes/Projection/ProjectionManager.php
+++ b/Classes/Projection/ProjectionManager.php
@@ -14,7 +14,7 @@ namespace Neos\EventSourcing\Projection;
 use Neos\EventSourcing\Event\EventTypeResolver;
 use Neos\EventSourcing\EventListener\EventListenerLocator;
 use Neos\EventSourcing\EventListener\AsynchronousEventListenerInterface;
-use Neos\EventSourcing\EventStore\EventStore;
+use Neos\EventSourcing\EventStore\EventStoreManager;
 use Neos\EventSourcing\EventStore\EventTypesFilter;
 use Neos\EventSourcing\EventStore\Exception\EventStreamNotFoundException;
 use Neos\Flow\Annotations as Flow;
@@ -57,9 +57,9 @@ class ProjectionManager
 
     /**
      * @Flow\Inject
-     * @var EventStore
+     * @var EventStoreManager
      */
-    protected $eventStore;
+    protected $eventStoreManager;
 
     /**
      * @var array in the format ['<projectionIdentifier>' => '<projectorClassName>', ...]
@@ -131,8 +131,9 @@ class ProjectionManager
 
         $filter = new EventTypesFilter($projection->getEventTypes());
 
+        $eventStore = $this->eventStoreManager->getEventStoreForEventListener($projection->getProjectorClassName());
         try {
-            $eventStream = $this->eventStore->get($filter);
+            $eventStream = $eventStore->get($filter);
         } catch (EventStreamNotFoundException $exception) {
             return;
         }
@@ -169,8 +170,9 @@ class ProjectionManager
         $lastAppliedSequenceNumber = $projector->getHighestAppliedSequenceNumber();
 
         $filter = new EventTypesFilter($projection->getEventTypes(), $lastAppliedSequenceNumber + 1);
+        $eventStore = $this->eventStoreManager->getEventStoreForEventListener($projection->getProjectorClassName());
         try {
-            $eventStream = $this->eventStore->get($filter);
+            $eventStream = $eventStore->get($filter);
         } catch (EventStreamNotFoundException $exception) {
             return;
         }

--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -1,5 +1,7 @@
-Neos\EventSourcing\EventStore\Storage\EventStorageInterface:
-  className: Neos\EventSourcing\EventStore\Storage\Doctrine\DoctrineEventStorage
+Neos\EventSourcing\EventStore\EventStoreManager:
+  arguments:
+    2:
+      setting: 'Neos.EventSourcing.EventStore.stores'
 
 Neos\EventSourcing\Projection\ProjectionManager:
   properties:

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -2,19 +2,40 @@
 Neos:
   EventSourcing:
     EventStore:
-      storage:
-        options:
-          eventTableName: neos_eventsourcing_eventstore_events
-          backendOptions:
-            driver: pdo_mysql
-            host: 127.0.0.1
-            dbname: null
-            user: null
-            password: null
-            charset: utf8
+      stores:
+        'default':
+          boundedContexts:
+            # This Event Store is configured to be used as "fallback"
+            '*': true
+
+          # By default the DoctrineEventStorage adapter is used, but this can be changed with the following setting:
+          storage: 'Neos\EventSourcing\EventStore\Storage\Doctrine\DoctrineEventStorage'
+
+          storageOptions:
+
+             # When using the DoctrineEventStorage adapter events are stored in a table called "neos_eventsourcing_eventstore_events" by default. This can be changed per Event Store:
+#            eventTableName: 'some_package_custom_events'
+
+             # By default the Flow database connection is reused for the EventEvent store backend, but this can be changed per Event Store. Note: BackendOptions will be merged with the Flow default backend options
+#            backendOptions:
+#              driver: pdo_mysql
+#              host: 127.0.0.1
+#              dbname: null
+#              user: null
+#              password: null
+#              charset: utf8
+
+           # Custom mapping types can be configured (only useful when using a _different_ database connection for the Event Store)
+#          mappingTypes:
+#            'some_custom_type':
+#              dbType: 'json_array'
+#              className: 'Some\Type\Implementation'
+
+
+  # Ignore the default Event Store table ("neos_eventsourcing_eventstore_events") when creating Doctrine migrations
   Flow:
     persistence:
       doctrine:
         migrations:
           ignoredTables:
-            neos_eventsourcing_eventstore_events: true
+            'neos_eventsourcing_eventstore_events': true

--- a/Tests/Unit/EventStore/EventStoreManagerTest.php
+++ b/Tests/Unit/EventStore/EventStoreManagerTest.php
@@ -1,0 +1,419 @@
+<?php
+namespace Neos\EventSourcing\Tests\Unit\EventStore;
+
+use Neos\EventSourcing\EventStore\EventStore;
+use Neos\EventSourcing\EventStore\EventStoreManager;
+use Neos\EventSourcing\EventStore\Storage\EventStorageInterface;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
+use Neos\Flow\Tests\UnitTestCase;
+use Neos\Utility\ObjectAccess;
+
+class EventStoreManagerTest extends UnitTestCase
+{
+
+    /**
+     * @var EventStoreManager
+     */
+    private $eventStoreManager;
+
+    /**
+     * @var EventStorageInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $mockEventStorage;
+
+    /**
+     * @var EventStore|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $mockEventStore;
+
+    /**
+     * @var ObjectManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $mockObjectManager;
+
+    public function setUp()
+    {
+        $this->mockObjectManager = $this->getMockBuilder(ObjectManagerInterface::class)->getMock();
+
+        $this->mockEventStorage = $this->getMockBuilder(EventStorageInterface::class)->getMock();
+        $this->mockEventStore = new EventStore($this->mockEventStorage);
+
+        $mockConfiguration = [
+            'fallbackStore' => [
+                'storage' => 'fallbackStoreStorage',
+                'boundedContexts' => [
+                    '*' => true,
+                    'Bounded.Context1' => true,
+                ],
+            ],
+            'eventStore2' => [
+                'storage' => 'eventStore2Storage',
+                'boundedContexts' => [
+                    'Bounded.Context2' => true,
+                ],
+            ],
+            'eventStore3' => [
+                'storage' => 'eventStore3Storage',
+                'boundedContexts' => [
+                    'Bounded.Context3' => true,
+                    'Bounded.Context2.Sub' => true,
+                    'Bounded.Context23' => true,
+                    'Inactive' => false,
+                ],
+            ],
+        ];
+        $this->eventStoreManager = new EventStoreManager($this->mockObjectManager, $mockConfiguration);
+    }
+
+    /**
+     * @test
+     * @expectedException \Neos\EventSourcing\EventStore\Exception\StorageConfigurationException
+     * @expectedExceptionCode 1479213813
+     */
+    public function getEventStoreThrowsExceptionForEventStoreConfigurationsWithoutBoundedContextTarget()
+    {
+        $mockConfiguration = [
+            'someStore' => [
+                'storage' => 'Foo',
+                'boundedContexts' => [],
+            ],
+        ];
+        $eventStoreManager = new EventStoreManager($this->mockObjectManager, $mockConfiguration);
+        $eventStoreManager->getEventStore('someStore');
+    }
+
+    /**
+     * @test
+     * @expectedException \Neos\EventSourcing\EventStore\Exception\StorageConfigurationException
+     * @expectedExceptionCode 1479214520
+     */
+    public function getEventStoreThrowsExceptionIfNoFallbackStoreIsConfigured()
+    {
+        $mockConfiguration = [];
+        $eventStoreManager = new EventStoreManager($this->mockObjectManager, $mockConfiguration);
+        $eventStoreManager->getEventStore('someStore');
+    }
+
+    /**
+     * @test
+     * @expectedException \Neos\EventSourcing\EventStore\Exception\StorageConfigurationException
+     * @expectedExceptionCode 1492434176
+     */
+    public function getEventStoreThrowsExceptionForEventStoreConfigurationsWithOverlappingBoundedContexts()
+    {
+        $mockConfiguration = [
+            'someStore' => [
+                'storage' => 'Foo',
+                'boundedContexts' => [
+                    'Bounded:Context1' => true,
+                    'Bounded:Context2' => true,
+                    '*' => true,
+                ],
+            ],
+            'someOtherStore' => [
+                'storage' => 'Bar',
+                'boundedContexts' => [
+                    'Bounded:Context2' => true,
+                    'Bounded:Context3' => true,
+                ],
+            ],
+        ];
+        $eventStoreManager = new EventStoreManager($this->mockObjectManager, $mockConfiguration);
+        $eventStoreManager->getEventStore('someStore');
+    }
+
+    /**
+     * @test
+     * @expectedException \RuntimeException
+     * @expectedExceptionCode 1492610857
+     */
+    public function getEventStoreThrowsExceptionIfTheRequestedEventStoreIsNotConfigured()
+    {
+        $mockConfiguration = [
+            'someStore' => [
+                'storage' => 'Foo',
+                'boundedContexts' => [
+                    '*' => true,
+                ],
+            ],
+            'someOtherStore' => [
+                'storage' => 'Bar',
+                'boundedContexts' => [
+                    'SomeBounded:Context' => true,
+                ],
+            ],
+        ];
+        $eventStoreManager = new EventStoreManager($this->mockObjectManager, $mockConfiguration);
+        $eventStoreManager->getEventStore('someNonExistingStore');
+    }
+
+    /**
+     * @test
+     * @expectedException \Neos\EventSourcing\EventStore\Exception\StorageConfigurationException
+     * @expectedExceptionCode 1492610902
+     */
+    public function getEventStoreThrowsExceptionIfNoStorageIsConfigured()
+    {
+        $mockConfiguration = [
+            'someStore' => [
+                'boundedContexts' => [
+                    '*' => true,
+                ],
+            ],
+        ];
+        $eventStoreManager = new EventStoreManager($this->mockObjectManager, $mockConfiguration);
+        $eventStoreManager->getEventStore('someStore');
+    }
+
+    /**
+     * @test
+     * @expectedException \Neos\EventSourcing\EventStore\Exception\StorageConfigurationException
+     * @expectedExceptionCode 1492610908
+     */
+    public function getEventStoreThrowsExceptionIfConfiguredStorageIsNoEventStorageInterface()
+    {
+        $mockConfiguration = [
+            'someStore' => [
+                'storage' => 'EventStorageClassName',
+                'boundedContexts' => [
+                    '*' => true,
+                ],
+            ],
+        ];
+        $eventStoreManager = new EventStoreManager($this->mockObjectManager, $mockConfiguration);
+
+        $this->mockObjectManager->expects($this->once())->method('get')->with('EventStorageClassName')->will($this->returnValue(new \stdClass()));
+        $eventStoreManager->getEventStore('someStore');
+    }
+
+    /**
+     * @test
+     */
+    public function getEventStoreReturnsAnInstanceOfEventStoreWithTheConfiguredStorage()
+    {
+        $mockStorageOptions = ['foo' => 'Bar'];
+        $mockConfiguration = [
+            'someStore' => [
+                'storage' => get_class($this->mockEventStorage),
+                'storageOptions' => $mockStorageOptions,
+                'boundedContexts' => [
+                    '*' => true,
+                ],
+            ],
+        ];
+        $eventStoreManager = new EventStoreManager($this->mockObjectManager, $mockConfiguration);
+
+        $this->mockObjectManager->expects($this->at(0))->method('get')->with(get_class($this->mockEventStorage), $mockStorageOptions)->will($this->returnValue($this->mockEventStorage));
+        $this->mockObjectManager->expects($this->at(1))->method('get')->with(EventStore::class, $this->mockEventStorage)->will($this->returnValue($this->mockEventStore));
+
+        $eventStoreManager->getEventStore('someStore');
+        $eventStore = $eventStoreManager->getEventStore('someStore');
+
+        $this->mockEventStorage->expects($this->once())->method('setup');
+        $eventStore->setup();
+    }
+
+    /**
+     * @test
+     */
+    public function eventStoresAreInstantiatedLazily()
+    {
+        $mockConfiguration = [
+            'eventStore1' => [
+                'storage' => 'EventStorage1',
+                'boundedContexts' => [
+                    '*' => true,
+                ],
+            ],
+            'eventStore2' => [
+                'storage' => 'EventStorage2',
+                'boundedContexts' => [
+                    'Foo' => true,
+                ]
+            ],
+        ];
+        $eventStoreManager = new EventStoreManager($this->mockObjectManager, $mockConfiguration);
+
+        $this->mockObjectManager->expects($this->atLeastOnce())->method('get')->will($this->returnCallback(function($className) {
+            switch ($className) {
+                case EventStore::class:
+                    return $this->mockEventStore;
+                case 'EventStorage2':
+                    return $this->mockEventStorage;
+                default:
+                    $this->fail(sprintf('Class "%s" were not expected to be instantiated!', $className));
+            }
+            return '';
+        }));
+
+        $eventStoreManager->getEventStore('eventStore2');
+    }
+
+    public function getEventStoreForStreamNameDataProvider()
+    {
+        return [
+            ['streamName' => '', 'expectedEventStore' => 'fallbackStore'],
+            ['streamName' => 'Inactive', 'expectedEventStore' => 'fallbackStore'],
+            ['streamName' => 'NoMatch', 'expectedEventStore' => 'fallbackStore'],
+            ['streamName' => 'NoMatch:Foo', 'expectedEventStore' => 'fallbackStore'],
+            ['streamName' => 'Bounded.Context1:Foo', 'expectedEventStore' => 'fallbackStore'],
+            ['streamName' => 'Bounded.Context234:Foo', 'expectedEventStore' => 'fallbackStore'],
+            ['streamName' => 'Bounded.Context2', 'expectedEventStore' => 'eventStore2'],
+            ['streamName' => 'Bounded.Context2:Foo', 'expectedEventStore' => 'eventStore2'],
+            ['streamName' => 'Bounded.Context23', 'expectedEventStore' => 'eventStore3'],
+            ['streamName' => 'Bounded.Context23:Foo', 'expectedEventStore' => 'eventStore3'],
+            ['streamName' => 'Bounded.Context2.Sub', 'expectedEventStore' => 'eventStore3'],
+            ['streamName' => 'Bounded.Context2.Sub:Foo', 'expectedEventStore' => 'eventStore3'],
+            ['streamName' => 'Bounded.Context3:Xyz', 'expectedEventStore' => 'eventStore3'],
+        ];
+    }
+
+    /**
+     * @param string $streamName
+     * @param string $expectedEventStore
+     * @test
+     * @dataProvider getEventStoreForStreamNameDataProvider
+     */
+    public function getEventStoreForStreamNameTests(string $streamName, string $expectedEventStore)
+    {
+        $this->mockObjectManager->expects($this->atLeastOnce())->method('get')->will($this->returnCallback(function($className) use ($expectedEventStore) {
+            $storageClassName = $expectedEventStore . 'Storage';
+            switch ($className) {
+                case EventStore::class:
+                    return $this->mockEventStore;
+                case $storageClassName;
+                    return $this->mockEventStorage;
+                default:
+                    $this->fail(sprintf('Class "%s" were not expected to be instantiated, expected "%s" or "%s"', $className, $storageClassName, EventStore::class));
+            }
+            return '';
+        }));
+
+        $this->eventStoreManager->getEventStoreForStreamName($streamName);
+    }
+
+    /**
+     * @test
+     */
+    public function getEventStoreForEventListenerReturnsFallbackEventStoreIfAnEmptyStringIsGiven()
+    {
+        $this->mockObjectManager->expects($this->at(0))->method('getPackageKeyByObjectName')->with('')->will($this->returnValue(false));
+        $this->mockObjectManager->expects($this->at(1))->method('get')->with('fallbackStoreStorage')->will($this->returnValue($this->mockEventStorage));
+        $this->mockObjectManager->expects($this->at(2))->method('get')->with(EventStore::class, $this->mockEventStorage)->will($this->returnValue($this->mockEventStore));
+        $eventStore = $this->eventStoreManager->getEventStoreForEventListener('');
+        $this->assertSame($this->mockEventStore, $eventStore);
+    }
+
+    public function getEventStoreForEventListenerDataProvider()
+    {
+        return [
+            ['resolvedPackageKey' => '', 'expectedEventStore' => 'fallbackStore'],
+            ['resolvedPackageKey' => 'NoMatch', 'expectedEventStore' => 'fallbackStore'],
+            ['resolvedPackageKey' => 'Inactive', 'expectedEventStore' => 'fallbackStore'],
+            ['resolvedPackageKey' => 'Bounded.Context1', 'expectedEventStore' => 'fallbackStore'],
+            ['resolvedPackageKey' => 'Bounded.Context234', 'expectedEventStore' => 'fallbackStore'],
+            ['resolvedPackageKey' => 'Bounded.Context2', 'expectedEventStore' => 'eventStore2'],
+            ['resolvedPackageKey' => 'Bounded.Context23', 'expectedEventStore' => 'eventStore3'],
+            ['resolvedPackageKey' => 'Bounded.Context2.Sub', 'expectedEventStore' => 'eventStore3'],
+            ['resolvedPackageKey' => 'Bounded.Context3', 'expectedEventStore' => 'eventStore3'],
+        ];
+    }
+
+    /**
+     * @param string $resolvedPackageKey
+     * @param string $expectedEventStore
+     * @test
+     * @dataProvider getEventStoreForEventListenerDataProvider
+     */
+    public function getEventStoreForEventListenerTests(string $resolvedPackageKey, string $expectedEventStore)
+    {
+        $this->mockObjectManager->expects($this->at(0))->method('getPackageKeyByObjectName')->with('listenerClassName')->will($this->returnValue($resolvedPackageKey));
+        $this->mockObjectManager->expects($this->atLeastOnce())->method('get')->will($this->returnCallback(function($className) use ($expectedEventStore) {
+            $storageClassName = $expectedEventStore . 'Storage';
+            switch ($className) {
+                case EventStore::class:
+                    return $this->mockEventStore;
+                case $storageClassName;
+                    return $this->mockEventStorage;
+                default:
+                    $this->fail(sprintf('Class "%s" were not expected to be instantiated, expected "%s" or "%s"', $className, $storageClassName, EventStore::class));
+            }
+            return '';
+        }));
+
+        $this->eventStoreManager->getEventStoreForEventListener('listenerClassName');
+    }
+
+    public function getEventStoreForBoundedContextDataProvider()
+    {
+        return [
+            ['boundedContext' => '', 'expectedEventStore' => 'fallbackStore'],
+            ['boundedContext' => 'NoMatch', 'expectedEventStore' => 'fallbackStore'],
+            ['boundedContext' => 'Inactive', 'expectedEventStore' => 'fallbackStore'],
+            ['boundedContext' => 'NoMatch:Foo', 'expectedEventStore' => 'fallbackStore'],
+            ['boundedContext' => 'Bounded.Context1', 'expectedEventStore' => 'fallbackStore'],
+            ['boundedContext' => 'Bounded.Context234', 'expectedEventStore' => 'fallbackStore'],
+            ['boundedContext' => 'Bounded.Context2', 'expectedEventStore' => 'eventStore2'],
+            ['boundedContext' => 'Bounded.Context23', 'expectedEventStore' => 'eventStore3'],
+            ['boundedContext' => 'Bounded.Context2.Sub', 'expectedEventStore' => 'eventStore3'],
+            ['boundedContext' => 'Bounded.Context3', 'expectedEventStore' => 'eventStore3'],
+        ];
+    }
+
+    /**
+     * @param string $boundedContext
+     * @param string $expectedEventStore
+     * @test
+     * @dataProvider getEventStoreForBoundedContextDataProvider
+     */
+    public function getEventStoreForBoundedContextTests(string $boundedContext, string $expectedEventStore)
+    {
+        $this->mockObjectManager->expects($this->atLeastOnce())->method('get')->will($this->returnCallback(function($className) use ($expectedEventStore) {
+            $storageClassName = $expectedEventStore . 'Storage';
+            switch ($className) {
+                case EventStore::class:
+                    return $this->mockEventStore;
+                case $storageClassName;
+                    return $this->mockEventStorage;
+                default:
+                    $this->fail(sprintf('Class "%s" were not expected to be instantiated, expected "%s" or "%s"', $className, $storageClassName, EventStore::class));
+            }
+            return '';
+        }));
+
+        $this->eventStoreManager->getEventStoreForBoundedContext($boundedContext);
+    }
+
+    /**
+     * @test
+     * @expectedException \Neos\EventSourcing\EventStore\Exception\StorageConfigurationException
+     */
+    public function getAllEventStoresThrowsExceptionIfNoEventStoreIsConfigured()
+    {
+        $mockConfiguration = [];
+        $eventStoreManager = new EventStoreManager($this->mockObjectManager, $mockConfiguration);
+        $eventStoreManager->getAllEventStores();
+    }
+
+    /**
+     * @test
+     */
+    public function getAllEventStoresInstantiatesAndReturnsAllConfiguredEventStores()
+    {
+        $mockEventStores = [
+            'fallbackStore' => new EventStore($this->mockEventStorage),
+            'eventStore2' => new EventStore($this->mockEventStorage),
+            'eventStore3' => new EventStore($this->mockEventStorage),
+        ];
+
+        $this->mockObjectManager->expects($this->at(0))->method('get')->with('fallbackStoreStorage')->will($this->returnValue($this->mockEventStorage));
+        $this->mockObjectManager->expects($this->at(1))->method('get')->with(EventStore::class)->will($this->returnValue($mockEventStores['fallbackStore']));
+        $this->mockObjectManager->expects($this->at(2))->method('get')->with('eventStore2Storage')->will($this->returnValue($this->mockEventStorage));
+        $this->mockObjectManager->expects($this->at(3))->method('get')->with(EventStore::class)->will($this->returnValue($mockEventStores['eventStore2']));
+        $this->mockObjectManager->expects($this->at(4))->method('get')->with('eventStore3Storage')->will($this->returnValue($this->mockEventStorage));
+        $this->mockObjectManager->expects($this->at(5))->method('get')->with(EventStore::class)->will($this->returnValue($mockEventStores['eventStore3']));
+
+        $actualResult = $this->eventStoreManager->getAllEventStores();
+        $this->assertSame($mockEventStores, $actualResult);
+    }
+}


### PR DESCRIPTION
This feature allows multiple Event Store backends to be used within the same Flow installation.
With that it's possible to use separate database tables or completely different backends for certain event types.

When using the provided `DoctrineEventStorage` backend, the database connection options is now merged with the Flows default persistence backend options.
As a result the `default` Event Store uses the same DB connection circumventing #42.

In order to store events from a package `Some.Package` to a different database table, that's all you need to configure:

```yaml
Neos:
  EventSourcing:
    EventStore:
      stores:
        'someCustomStore':
          boundedContexts:
            'Some.Package': true
          storage: 'Neos\EventSourcing\EventStore\Storage\Doctrine\DoctrineEventStorage'
          storageOptions:
            eventTableName: 'some_custom_event_table'
```

To use a separate database altogether, the `backendOptions` can be changed, too:

```yaml
Neos:
  EventSourcing:
    EventStore:
      stores:
        'someCustomStore':
          # ...
          storageOptions:
            backendOptions:
              driver: 'pdo_sqlite'
              path: '/some/path/events.db'
              username: ~
              password: ~
```

Or, of course, a completely different adapter implementation can be used, by setting the `storage` option to a class name that implements `EventStorageInterface`.

This change also overhauls the `eventstore` CLI replacing the `createSchema` and `dropSchema` commands with the more general purpose commands `setup`, `setupall` and `status`.

Resolves: #55
Fixes: #42