### PR TITLE
TASK: Update and restructure Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -158,7 +158,7 @@ final class ProductedWasOrdered implements EventInterface
     }
 
     /**
-     * @return integer
+     * @return int
      */
     public function getAmount(): int
     {

--- a/Readme.md
+++ b/Readme.md
@@ -288,7 +288,9 @@ t.b.w.
 
 ### EventPublisher
 
-t.b.w.
+You can use the EventPublisher directly to record and distribute events outside of your Aggregates. For that, just inject
+it into your CommandHandler and emit new Domain Events there according to an incoming command which does not touch
+any hard business constraints that need to be enforced by an Aggregate.
 
 # Query / Read side
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,104 +1,90 @@
 # Event Sourcing and CQRS for Flow Framework
 
-_This package is currently under development and not fully working, please don't use it in production._
+_This package is currently under development and not fully tested, please don't use it in production._
 
-The goal of the project is to provide the infrastructure for ES/CQRS for applications based on Flow Framework.
+The goal of the project is to provide the infrastructure to apply an ES/CQRS pattern for applications based on Flow Framework.
 
 # DISCLAIMER
 
-**Please note:** This documentation (as well as the inline docs) are not up to date with the implementation of this package unfortunately.
-We are about to change that. Please bear with us in the meantime and [get in touch](https://www.neos.io/docs-and-support/support.html) if you have any questions!
+**Please note:** This documentation (as well as the inline docs) might not be up to date with the implementation of this package unfortunately.
+If you find any errors, please let us know or directly create a PR.
+
+Please bear with us in the meantime and [get in touch](https://www.neos.io/docs-and-support/support.html) if you have any questions!
 
 # Requirements
 
 * PHP 7
 * Flow 4.0
 
-# Configuration
+# Recommended Project Structure
 
-To be able to send events to a different DB, the ES package uses its own DB connection. These are the defaults which you will need to override:
+We highly recommend a PSR-4 folder structure and separating every `Bounded Context` into it's own package.
+We have an ongoing discussion about how to structure the code here: https://github.com/neos/Neos.EventSourcing/issues/9
+Our *current* recommendation (as of April 2017) for the structure is as follows:
 
-```
-Neos:
-  EventSourcing:
-    EventStore:
-      storage:
-        options:
-          eventTableName: neos_eventsourcing_eventstore_events
-          backendOptions:
-            driver: pdo_mysql
-            host: 127.0.0.1
-            dbname: null
-            user: null
-            password: null
-            charset: utf8
-```
-
-If you want the package to use the same DB connection your main application uses and want to save on typing, you can use YAML path references to point the ES storage config to the main one.
-```
-Neos:
-  Flow:
-    persistence:
-      # Add the "&mybackend" reference here (name it however you want, just keep the & in the beginning)
-      backendOptions: &mybackend
-        # Your usual DB credentials / config here [...]
-
-  EventSourcing:
-    EventStore:
-      storage:
-        options:
-          backendOptions: *mybackend
-```
-
-# Packages
-
-The features are split into different packages:
-
-* **[Neos.EventSourcing](https://github.com/neos/Neos.EventSourcing)**: mostly infrastructure (interface, trait, abstract class) and the event/query bus
-* **[Neos.EventSourcing.MonitoringHelper](https://github.com/neos/Neos.EventSourcing.MonitoringHelper)**: aspect to monitor performance of the ```Neos.EventSourcing``` infrastructure
-* **[Neos.EventStore](https://github.com/neos/Neos.EventStore)**: event store to support event sourcing
-* **[Neos.EventSourcing.InMemoryStorageAdapter](https://github.com/neos/Neos.EventSourcing.InMemoryStorageAdapter)**: in memory event storage, mainly for testing
-* **[Neos.EventSourcing.DatabaseStorageAdapter](https://github.com/neos/Neos.EventSourcing.DatabaseStorageAdapter)**: doctrine dbal based event storage
-
-More storage can be added later (Redis, ...).
-
-# Folder Structure
-
-This is a PSR-4 package structure:
-
-    Your.Package/
-      Application/
+    Your.BoundedContextPackage.Command/
+      Classes/
         Controller/
-        Command/
+          [UseCase]Controller.php
+          …
         Service/
-        Projection/
-            [ProjectionName]/
-                [ProjectionName]Finder.php
-                [ProjectionName]Projector.php
-                [ProjectionName].php
-
-      CommandHandler/
-
-      Domain/
-        Service/
-        Aggregate/
+          [SomeDomain]Service.php
+          …
+        Model/
           [YourAggregate]/
             Command/
+              [DoSomething].php
+              …
             Event/
-            Service/
-            YourAggregate.php
-            YourAggregateRepository.php
+              [SomethingHappened].php
+              …
+            [YourAggregate].php
+            [YourAggregate]CommandHandler.php
+            [YourAggregate]Repository.php
+          …
+        Process/
+          [Some]ProcessManager.php
+          …
 
-      EventListener/
+    Your.BoundedContextPackage.Query/
+      Classes/
+        Controller/
+          [ReadUseCase]Controller.php
+          …
+        Dto/
+          [SomeQueryDto].php
+          …
+        Service/
+          [SomeNonDomain]Service.php
+          …
+        Projection/
+          [ProjectionName]/
+            [ProjectionName].php
+            [ProjectionName]Finder.php
+            [ProjectionName]Projector.php
+          …
 
-# Components
+The reason to separate your Command and Query sides into own Packages is to make it clear those are fully separate
+parts of your application. However, it is no problem to have both parts inside a single package.
 
-Currently most components are included in the ```Neos.EventSourcing``` package. In the future some components can be split into
-separate packages for more flexibility.
+Also note that this is just a recommendation and not a necessary structure for anything to work as expected.
+The only requirements are the naming conventions for the Aggregate Repository and the Projection Finder and Projector.
+Those can be easily overruled in the code through the respective properties ```aggregateClassName``` and ```readModelClassName``` though.
 
-## Command
+# Command / Write side
+
+Your write side models your core domain logic, ensuring consistency and keeping business rules intact.
+It's public API is defined by the Commands and Events. Business constraints are commonly modelled through Aggregates and
+processes through ProcessManagers.
+
+There are many cases though where you can get along without the latter two and only end up with CommandHandlers that
+receive Commands and emit Events (through the ```EventPublisher```).
+
+## Core Domain
 
 ### Command
+
+The command models a single very specific intention to change your application.
 
 ```php
 final class ConfirmOrder
@@ -127,62 +113,18 @@ final class ConfirmOrder
 }
 ```
 
-### CommandHandler
-
-```php
-/**
- * @Flow\Scope("singleton")
- */
-class ButtonCommandHandler
-{
-    /**
-     * @var ButtonRepository
-     * @Flow\Inject
-     */
-    protected $buttonRepository;
-
-    /**
-     * @param CreateButton $command
-     */
-    public function handleCreateButton(CreateButton $command)
-    {
-        $button = new Button($command->getIdentifier(), $command->getPublicIdentifier());
-        $button->changeLabel($command->getLabel());
-
-        $this->buttonRepository->save($button);
-    }
-}
-```
-
-### Monitoring
-
-You can disable (enabled by default) the command handler performance monitoring. The monitoring is implemented with AOP,
-check ```Settings.yaml``` for the configuration.
-
-## Domain
-
-* [x] **AggregateRoot**: implement your own based on ```AggregateRootInterface``` with ```AggregateRootTrait```
-* [x] **Repository**: implement your own based on ```RepositoryInterface```
-
-## Event
-
-### EventBus
-
-* [x] **EventBus**: default implementation, implement your own based on ```EventBusInterface```
-
-### EventListenerLocator
-
-* [x] **EventListenerLocator**: based on convention, implement your own based on ```EventListenerLocatorInterface```
+Notice that the commands do not have any dependency on the framework. They are pure POJOs and
+should optimally be immutable.
 
 ### Event
 
-* [x] **Event**: implement your own based on ```EventInterface```
-
-This interface contains no methods, so you are free to focus on your domain. The interface is used by Flow to provide
-infrastructure helpers (monitoring, debugging, ...).
+Events model a fact that something happened in your domain that is of interest. They should be fully self-contained
+with all information that is necessary to derive a meaningful interpretation of the fact and be immutable.
+Events need to implement the ```EventInterface``` marker Interface, which contains no methods, so you are free to focus on your domain.
+The interface is used by Flow to provide infrastructure helpers (monitoring, debugging, ...).
 
 ```php
-class ProductedOrdered implements EventInterface
+final class ProductedOrdered implements EventInterface
 {
     /**
      * @var string
@@ -195,7 +137,8 @@ class ProductedOrdered implements EventInterface
     protected $amount;
 
     /**
-     * @param string $publicIdentifier
+     * @param string $productIdentifier
+     * @param integer $amount
      */
     public function __construct(string $productIdentifier, int $amount)
     {
@@ -212,7 +155,7 @@ class ProductedOrdered implements EventInterface
     }
 
     /**
-     * @return string
+     * @return integer
      */
     public function getAmount(): int
     {
@@ -240,55 +183,55 @@ final class SomethingHappenedElsewhere implements EventInterface, ProvidesEventT
 }
 ```
 
-### Generic Fault (WIP)
-
-* [x] **GenericFault**: event triggered by the EventBus is an event handler throw an exception
-
-### How to implement you own event listener ?
-
-Your must implement the ```EventListenerInterface```:
+### CommandHandlers
 
 ```php
-class ConsoleOutputListener implements EventListenerInterface
+/**
+ * @Flow\Scope("singleton")
+ */
+final class ButtonCommandHandler
 {
     /**
-     * @var SystemLoggerInterface
+     * @var ButtonRepository
      * @Flow\Inject
      */
-    protected $systemLogger;
+    protected $buttons;
 
     /**
-     * @param ButtonTagged $event
-     * @param EventMetadata $metadata
+     * @param CreateButton $command
      */
-    public function onButtonTagged(ButtonTagged $event, EventMetadata $metadata)
+    public function handleCreateButton(CreateButton $command)
     {
-        $this->systemLogger->log('--- ConsoleOutputListener say something has been tagged ---');
+        $button = new Button($command->getIdentifier());
+        $button->changeLabel($command->getLabel());
+
+        $this->buttons->save($button);
     }
 }
 ```
 
-The event handler locator can throw an exception if something is wrong with your command handler definition. In that
-case please check your system log for more information.
+The CommandHandler is currently not a formal part of the Framework, but is a recommended abstraction to introduce
+in order to easily support dispatching commands through other entry points (e.g. CLI). It might be introduced (again)
+later on in combination with an CommandBus to provide a single (asynchronous) dispatch entry point.
 
-All the wiring between event is done automatically, if you respect the following convention:
+### Aggregates
 
-* Method name must be on[ShortEventName]
-* The first parameter must be casted with your ```Event```
-* The second parameter is optional, but should be casted to ```EventMetadata```
+t.b.w.
 
-## EventStore
+### ProcessManagers
 
-See package **Neos.EventSourcing**.
+t.b.w.
 
-## Message
+### EventPublisher
 
-Messaging infrastructure, base class/traits to build your own Events.
+t.b.w.
+
+# Query / Read side
+
+Your read side is mainly made up of one or multiple Projections and all the Application logic around them,
+e.g. the typical Flow MVC components like Controller(s), DTOs, Templates and Layouts.
 
 ## Projections
-
-Because a projection is usually tailored to one or more views in an application, we recommend using the
-`Application\Projection\[ProjectionName]` namespace for the respective code.
 
 A projection usually consists of three classes: the Projector, the Finder and the Read Model.
 
@@ -300,6 +243,10 @@ updates its projection accordingly.
 The `add()`, `update()` and `remove()` methods are *protected*. Instead of manually adding, updating or removing
 objects, these methods are called by event handler methods contained in the Projector.
 
+#### Asynchronous projections / AsynchronousEventListenerInterface
+
+t.b.w.
+
 ### Finder
 
 The Finder provides methods for querying and retrieving the state of the projection in the form of Read Models.
@@ -307,10 +254,13 @@ It is typically used in controllers and other similar parts of the application f
 well-known `findBy*()` and `findOneBy` methods. In contrast to a Repository though, users cannot add, update or remove
 objects.
 
+> Note: Never use the Finder inside your Projector to query your projection state, only use the methods provided by the Projector itself.
+
 ### Read Model
 
 A Read Model is a simple PHP class which is used for passing around the state of a projection. It is also called a
-Data Transfer Object (DTO). The Finder will return its results as one or more Read Model instances.
+Data Transfer Object (DTO). The Finder will return its results as one or more Read Model instances. The Projector
+will update the projection state as one or more Read Model instances.
 
 ### Doctrine-based projections
 
@@ -321,11 +271,11 @@ The following Read Model is used in a projection for organizations. It has a few
 right after the code.
 
 ```php
-namespace Acme\Application\Projection\Organization;
+namespace Acme\Crm\Query\Projection\Organization;
 
-use TYPO3\Media\Domain\Model\AssetInterface;
-use TYPO3\Media\Domain\Repository\AssetRepository;
-use TYPO3\Flow\Annotations as Flow;
+use Neos\Media\Domain\Model\AssetInterface;
+use Neos\Media\Domain\Repository\AssetRepository;
+use Neos\Flow\Annotations as Flow;
 use Doctrine\ORM\Mapping as ORM;
 use Neos\EventSourcing\Annotations as CQRS;
 
@@ -365,6 +315,12 @@ class Organization
      * @var array
      */
     public $projects = [];
+
+    public function __construct(string $identifier, string $name)
+    {
+        $this->identifier = $identifier;
+        $this->name = $name;
+    }
 
     /**
      * @return AssetInterface|null
@@ -407,11 +363,11 @@ That means: `./flow doctrine:migrationgenerate`, adjust and `./flow doctrine:mig
 The corresponding Projector class for this example projection could look like this:
 
 ```php
-namespace Acme\Application\Projection\Organization;
+namespace Acme\Crm\Query\Projection\Organization;
 
-use Acme\Domain\Aggregate\Organization\Event\OrganizationHasBeenCreated;
-use Acme\Domain\Aggregate\Organization\Event\OrganizationHasBeenDeleted;
-use Acme\Domain\Aggregate\Organization\Event\OrganizationLogoHasBeenChanged;
+use Acme\Crm\Command\Model\Organization\Event\OrganizationHasBeenCreated;
+use Acme\Crm\Command\Model\Organization\Event\OrganizationHasBeenDeleted;
+use Acme\Crm\Command\Model\Organization\Event\OrganizationLogoHasBeenChanged;
 use Neos\EventSourcing\Projection\Doctrine\AbstractDoctrineProjector;
 use TYPO3\Flow\Annotations as Flow;
 
@@ -429,28 +385,27 @@ class OrganizationProjector extends AbstractDoctrineProjector
      */
     public function whenOrganizationHasBeenCreated(OrganizationHasBeenCreated $event)
     {
-        $organization = new Organization();
-        $this->mapEventToReadModel($event, $organization);
+        $organization = new Organization($event->getOrganizationIdentifier(), $event->getName());
         $this->add($organization);
     }
 
     /**
-     * @param \Acme\Domain\Aggregate\Organization\Event\OrganizationHasBeenDeleted $event
+     * @param OrganizationHasBeenDeleted $event
      * @return void
      */
     public function whenOrganizationHasBeenDeleted(OrganizationHasBeenDeleted $event)
     {
-        $organization = $this->get($event->getIdentifier());
+        $organization = $this->get($event->getOrganizationIdentifier());
         $this->remove($organization);
     }
 
     /**
-     * @param \Acme\Domain\Aggregate\Organization\Event\OrganizationLogoHasBeenChanged $event
+     * @param OrganizationLogoHasBeenChanged $event
      * @return void
      */
     public function whenOrganizationLogoHasBeenChanged(OrganizationLogoHasBeenChanged $event)
     {
-        $organization = $this->get($event->getIdentifier());
+        $organization = $this->get($event->getOrganizationIdentifier());
         $organization->logoIdentifier = $event->getLogoIdentifier();
         $this->update($organization);
     }
@@ -460,11 +415,11 @@ class OrganizationProjector extends AbstractDoctrineProjector
 The corresponding Finder class providing the query methods may look as simple as this:
 
 ```php
-namespace Acme\Application\Projection\Organization;
+namespace Acme\Crm\Query\Projection\Organization;
 
 use Neos\EventSourcing\Projection\Doctrine\AbstractDoctrineFinder;
-use TYPO3\Flow\Annotations as Flow;
-use TYPO3\Flow\Persistence\QueryInterface;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Persistence\QueryInterface;
 
 /**
  * Organization Finder
@@ -484,7 +439,41 @@ class OrganizationFinder extends AbstractDoctrineFinder
 }
 ```
 
-... todo: more explanations
+### How to implement you own event listener ?
+
+To implement other custom event listeners you only need to implement the `EventListenerInterface`:
+
+```php
+class ConsoleOutputListener implements EventListenerInterface
+{
+    /**
+     * @var SystemLoggerInterface
+     * @Flow\Inject
+     */
+    protected $systemLogger;
+
+    /**
+     * @param ButtonTagged $event
+     * @param EventMetadata $metadata
+     */
+    public function whenButtonTagged(ButtonTagged $event, RawEvent $rawEventData)
+    {
+        $this->systemLogger->log('--- ConsoleOutputListener say something has been tagged ---');
+    }
+}
+```
+
+The event handler locator can throw an exception if something is wrong with your command handler definition. In that
+case please check your system log for more information.
+
+All the wiring between event and event listeners is done automatically, if you respect the following convention:
+
+* Method name must be when[ShortEventName]
+* The first parameter must be of type `EventInterface` and is your concrete DomainEvent instance
+* The second parameter is optional and is of type `RawEvent`, containing the raw data and metadata from the EventStore
+
+Also, you can optionally let your `EventListener` implement `ActsBeforeInvokingEventListenerMethodsInterface`
+in order to receive a hook method `beforeInvokingEventListenerMethod` before the concrete event handling method (`when*`) is called.
 
 License
 -------


### PR DESCRIPTION
This brings the readme in line with the current state of implementation and conceptual consensus and slightly restructures it into a logical read order:

- start with basic information how a project can be structured
- explain the write side through it's API (commands + events)
- show a sample implementation of a `CommandHandler` to separate the entry point (web/cli) from the command handling logic (tbd: an implementation of a CommandHandler without using an Aggregate)
- explain how (hard) business constraints can be modelled with Aggregates (tbw)
- explain how business processes can be modelled with ProcessManagers (tbw)
- explain the read side conceptually via Projector, Finder and Read Model
- show how a Projection can be made asynchronous via `AsynchronousEventListenerInterface` (tbw)
- show how a Projection is implemented via `AbstractDoctrineProjector` et al
- show how custom event listeners can be implemented

This is not yet the structure of (growing) documentation we discussed, but rather an temporary solution to have *something* useful written down.