### PR TITLE
FEATURE: Introduce createQuery for Doctrine Projector

### DIFF
--- a/Classes/Projection/Doctrine/AbstractDoctrineProjector.php
+++ b/Classes/Projection/Doctrine/AbstractDoctrineProjector.php
@@ -99,6 +99,18 @@ abstract class AbstractDoctrineProjector extends AbstractBaseProjector
     }
 
     /**
+     * Creates a Doctrine Query object which can be used for specialized (bulk) operations.
+     * For use in the concrete projector.
+     *
+     * @param string $dql
+     * @return \Doctrine\ORM\Query
+     */
+    protected function createQuery(string $dql = '')
+    {
+        return $this->projectionPersistenceManager->createQuery($dql);
+    }
+
+    /**
      * Removes all objects of this repository as if remove() was called for all of them.
      * For usage in the concrete projector.
      *

--- a/Classes/Projection/Doctrine/DoctrineProjectionPersistenceManager.php
+++ b/Classes/Projection/Doctrine/DoctrineProjectionPersistenceManager.php
@@ -112,6 +112,17 @@ class DoctrineProjectionPersistenceManager
     }
 
     /**
+     * Creates a Query object which can be used for specialized (bulk) operations.
+     *
+     * @param string $dql
+     * @return \Doctrine\ORM\Query
+     */
+    public function createQuery(string $dql = '')
+    {
+        return $this->entityManager->createQuery($dql);
+    }
+
+    /**
      * Removes all objects from a Doctrine-based projection.
      *
      * @param string $readModelClassName Read Model class name of the projection


### PR DESCRIPTION
This introduces a `createQuery()` method for the `AbstractDoctrineProjector`
which allows for finding entries in event listeners of the concrete
projector.

Note that, especially during a projection replay, earlier changes might
not yet be persisted by Doctrine and thus can't be found by a query.
You will need to persist changes manually with `$this->projectionPersistenceManager->persistAll();`
in these cases.

Closes #136