### PR TITLE
BUGFIX: Fix EntityMananger initialization

### DIFF
--- a/Classes/EventStore/Storage/Doctrine/Factory/ConnectionFactory.php
+++ b/Classes/EventStore/Storage/Doctrine/Factory/ConnectionFactory.php
@@ -11,6 +11,7 @@ namespace Neos\EventSourcing\EventStore\Storage\Doctrine\Factory;
  * source code.
  */
 
+use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
@@ -25,6 +26,15 @@ use Neos\Utility\Arrays;
  */
 class ConnectionFactory
 {
+
+    /**
+     * NOTE: We inject the Doctrine ObjectManager in order to initialize the EntityManagerConfiguration::configureEntityManager
+     * slot is invoked. Without this an exception 'Unknown column type "flow_json_array" requested' might be thrown
+     *
+     * @Flow\Inject(lazy=false)
+     * @var ObjectManager
+     */
+    protected $doctrineObjectManager;
 
     /**
      * @var @Flow\InjectConfiguration(package="Neos.Flow", path="persistence.backendOptions")


### PR DESCRIPTION
When using the new `eventstore::setup*` command(s) introduced
with #138 in a Neos installation an exception was thrown:

    Unknown column type "flow_json_array" requested.

Reason for this is the `EntityManagerConfiguration::enhanceEntityManager`
slot that is only invoked if the `EntityManager` is acutally used.

This patch fixes that by injecting the Doctrine `ObjectManager` to
the `ConnectionFactory` so that the signal is fired.

Related: #55