### PR TITLE
TASK: Remove `getReadModelClassName()` method from `ProjectorInterface`

### DIFF
--- a/Classes/Projection/ProjectorInterface.php
+++ b/Classes/Projection/ProjectorInterface.php
@@ -18,13 +18,6 @@ use Neos\EventSourcing\EventListener\EventListenerInterface;
  */
 interface ProjectorInterface extends EventListenerInterface
 {
-    /**
-     * Returns the class name of the (main) Read Model of the concrete projector
-     *
-     * @return string
-     * @api
-     */
-    public function getReadModelClassName(): string;
 
     /**
      * Removes all objects of this repository as if remove() was called for all of them.


### PR DESCRIPTION
That method is only used by (and only makes sense for) the `AbstractDoctrine`
that needs it to create the DQL query based upon an entity.

The state of custom projectors might consist of many entities - or none at all.