### PR TITLE
BUGFIX: Recursively allow all properties when converting events

### DIFF
--- a/Classes/Event/EventPublisher.php
+++ b/Classes/Event/EventPublisher.php
@@ -20,9 +20,9 @@ use Neos\EventSourcing\EventStore\Exception\EventStreamNotFoundException;
 use Neos\EventSourcing\EventStore\ExpectedVersion;
 use Neos\EventSourcing\EventStore\WritableEvent;
 use Neos\EventSourcing\EventStore\WritableEvents;
+use Neos\EventSourcing\Property\AllowAllPropertiesPropertyMappingConfiguration;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Property\PropertyMapper;
-use Neos\Flow\Property\PropertyMappingConfiguration;
 use Neos\Flow\Utility\Algorithms;
 
 /**
@@ -104,9 +104,7 @@ class EventPublisher
         $eventStore = $this->eventStoreManager->getEventStoreForStreamName($streamName);
         $rawEvents = $eventStore->commit($streamName, $convertedEvents, $expectedVersion);
 
-        $configuration = new PropertyMappingConfiguration();
-        $configuration->allowAllProperties();
-        $configuration->forProperty('*')->allowAllProperties();
+        $configuration = new AllowAllPropertiesPropertyMappingConfiguration();
         foreach ($rawEvents as $rawEvent) {
             $eventClassName = $this->eventTypeResolver->getEventClassNameByType($rawEvent->getType());
             $event = $this->propertyMapper->convert($rawEvent->getPayload(), $eventClassName, $configuration);

--- a/Classes/EventStore/EventStream.php
+++ b/Classes/EventStore/EventStream.php
@@ -12,9 +12,9 @@ namespace Neos\EventSourcing\EventStore;
  */
 
 use Neos\EventSourcing\Event\EventTypeResolver;
+use Neos\EventSourcing\Property\AllowAllPropertiesPropertyMappingConfiguration;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Property\PropertyMapper;
-use Neos\Flow\Property\PropertyMappingConfiguration;
 
 /**
  * EventStream
@@ -51,10 +51,7 @@ final class EventStream implements \Iterator
      */
     public function current()
     {
-        $configuration = new PropertyMappingConfiguration();
-        $configuration->allowAllProperties();
-        $configuration->skipUnknownProperties();
-        $configuration->forProperty('*')->allowAllProperties()->skipUnknownProperties();
+        $configuration = new AllowAllPropertiesPropertyMappingConfiguration();
 
         /** @var RawEvent $rawEvent */
         $rawEvent = $this->streamIterator->current();

--- a/Classes/Property/AllowAllPropertiesPropertyMappingConfiguration.php
+++ b/Classes/Property/AllowAllPropertiesPropertyMappingConfiguration.php
@@ -1,0 +1,45 @@
+<?php
+namespace Neos\EventSourcing\Property;
+
+/*
+ * This file is part of the Neos.EventSourcing package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Property\PropertyMappingConfiguration;
+
+/**
+ * A property mapping configuration that allows all property recursively and skips unknown properties.
+ */
+class AllowAllPropertiesPropertyMappingConfiguration extends PropertyMappingConfiguration
+{
+
+    /**
+     * AllowAllPropertiesPropertyMappingConfiguration constructor.
+     */
+    public function __construct()
+    {
+        $this->allowAllProperties();
+        $this->skipUnknownProperties();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getConfigurationFor($propertyName)
+    {
+        if (isset($this->subConfigurationForProperty[$propertyName])) {
+            return $this->subConfigurationForProperty[$propertyName];
+        } elseif (isset($this->subConfigurationForProperty[self::PROPERTY_PATH_PLACEHOLDER])) {
+            return $this->subConfigurationForProperty[self::PROPERTY_PATH_PLACEHOLDER];
+        }
+
+        return new static();
+    }
+
+}

--- a/Classes/Property/AllowAllPropertiesPropertyMappingConfiguration.php
+++ b/Classes/Property/AllowAllPropertiesPropertyMappingConfiguration.php
@@ -41,5 +41,4 @@ class AllowAllPropertiesPropertyMappingConfiguration extends PropertyMappingConf
 
         return new static();
     }
-
 }


### PR DESCRIPTION
This fixes issues with nested value objects where a fixed hierarchy
for a property mapping configuration does not work.