### PR TITLE
FEATURE: Events with metadata

### DIFF
--- a/Classes/Event/EventPublisher.php
+++ b/Classes/Event/EventPublisher.php
@@ -94,8 +94,12 @@ class EventPublisher
     {
         $convertedEvents = new WritableEvents();
         foreach ($events as $event) {
-            $type = $this->eventTypeResolver->getEventType($event);
             $metadata = [];
+            if ($event instanceof EventWithMetadata) {
+                $metadata = $event->getMetadata();
+                $event = $event->getEvent();
+            }
+            $type = $this->eventTypeResolver->getEventType($event);
             $this->emitBeforePublishingEvent($event, $metadata);
             $data = $this->propertyMapper->convert($event, 'array');
             $eventIdentifier = Algorithms::generateUUID();

--- a/Classes/Event/EventWithMetadata.php
+++ b/Classes/Event/EventWithMetadata.php
@@ -1,0 +1,56 @@
+<?php
+namespace Neos\EventSourcing\Event;
+
+/*
+ * This file is part of the Neos.EventSourcing package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Event wrapper which provides metadata additional to the event
+ */
+final class EventWithMetadata implements EventInterface
+{
+    /**
+     * @var EventInterface
+     */
+    private $event;
+
+    /**
+     * @var array
+     */
+    private $metadata;
+
+    /**
+     * EventWithMetadata constructor.
+     *
+     * @param EventInterface $event
+     * @param array $metadata
+     */
+    public function __construct(EventInterface $event, array $metadata)
+    {
+        $this->event = $event;
+        $this->metadata = $metadata;
+    }
+
+    /**
+     * @return EventInterface
+     */
+    public function getEvent(): EventInterface
+    {
+        return $this->event;
+    }
+
+    /**
+     * @return array
+     */
+    public function getMetadata(): array
+    {
+        return $this->metadata;
+    }
+}

--- a/Readme.md
+++ b/Readme.md
@@ -292,6 +292,9 @@ You can use the EventPublisher directly to record and distribute events outside 
 it into your CommandHandler and emit new Domain Events there according to an incoming command which does not touch
 any hard business constraints that need to be enforced by an Aggregate.
 
+In order to provide additional metadata for the event (a simple array with keys and values), you can wrap the event into
+a `EventWithMetadata` object and pass that wrapper to the Event Publisher's publish function.
+
 # Query / Read side
 
 Your read side is mainly made up of one or multiple Projections and all the Application logic around them,


### PR DESCRIPTION
This change provides a simple and straight-forward way to specify metadata
along with an event when it is published.

In order to specify the metadata, simply wrap the event to be published with
and `EventWithMetadata` object and set the metadata there. This wrapper object
can be published like a normal even using `publish()` or `publishMany()`.