### PR TITLE
FEATURE: Allow EventWithMetadata to be nested

### DIFF
--- a/Classes/Event/EventWithMetadata.php
+++ b/Classes/Event/EventWithMetadata.php
@@ -11,6 +11,8 @@ namespace Neos\EventSourcing\Event;
  * source code.
  */
 
+use Neos\Utility\Arrays;
+
 /**
  * Event wrapper which provides metadata additional to the event
  */
@@ -35,7 +37,7 @@ final class EventWithMetadata implements EventInterface
     public function __construct(EventInterface $event, array $metadata)
     {
         $this->event = $event;
-        $this->metadata = $metadata;
+        $this->metadata = ($event instanceof EventWithMetadata) ? Arrays::arrayMergeRecursiveOverrule($event->getMetadata(), $metadata) : $metadata;
     }
 
     /**

--- a/Tests/Unit/Event/EventWithMetadataTest.php
+++ b/Tests/Unit/Event/EventWithMetadataTest.php
@@ -1,0 +1,55 @@
+<?php
+namespace Neos\EventSourcing\Tests\Unit\EventStore;
+
+use Neos\EventSourcing\Event\EventInterface;
+use Neos\EventSourcing\Event\EventWithMetadata;
+use Neos\Flow\Tests\UnitTestCase;
+
+class EventWithMetadataTest extends UnitTestCase
+{
+    /**
+     * @var EventInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $mockEvent;
+
+    public function setUp()
+    {
+        $this->mockEvent = $this->getMockBuilder(EventInterface::class)->getMock();
+    }
+
+    /**
+     * @test
+     */
+    public function originalEventCanBeRetrieved()
+    {
+        $eventWithMetadata = new EventWithMetadata($this->mockEvent, []);
+        $this->assertSame($this->mockEvent, $eventWithMetadata->getEvent());
+    }
+
+    /**
+     * @test
+     */
+    public function metadataCanBeRetrieved()
+    {
+        $someMetadata = ['foo' => ['bar' => 'Baz']];
+        $eventWithMetadata = new EventWithMetadata($this->mockEvent, $someMetadata);
+        $this->assertSame($someMetadata, $eventWithMetadata->getMetadata());
+    }
+
+
+    /**
+     * @test
+     */
+    public function eventsWithMetadataCanBeNested()
+    {
+        $someMetadata = ['foo' => ['bar' => 'Baz', 'foos' => 'bars']];
+        $eventWithMetadata = new EventWithMetadata($this->mockEvent, $someMetadata);
+
+        $someMoreMetadata = ['foo' => ['foos' => 'overridden'], 'another' => 'entry'];
+        $nestedEventWithMetadata = new EventWithMetadata($eventWithMetadata, $someMoreMetadata);
+
+        $mergedMetadata = ['foo' => ['bar' => 'Baz', 'foos' => 'overridden'], 'another' => 'entry'];
+
+        $this->assertSame($mergedMetadata, $nestedEventWithMetadata->getMetadata());
+    }
+}


### PR DESCRIPTION
Previously when nesting two or more `EventWithMetadata` instances
the outer most would override the metadata of the others.
This is fixed with this change.

It also adds unit tests for the new class.

Related: #152