### PR TITLE
TASK: Relax PHP version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "neos-package",
     "description": "Lean and opinionated way to integrate Event Sourcing and CQRS pattern in your Flow framework package",
     "require": {
-        "php": ">=7.0.1",
+        "php": ">=7.0",
         "neos/flow": "~4.0"
     },
     "suggest": {


### PR DESCRIPTION
This package required PHP `>= 7.0.1` which will conflict with a platform
dependency of `7.0`:
```
{
  // ...
  "config": {
    "platform": {
      "php": "7.0"
    }
}
```