### PR TITLE
TASK: Prevent `RawEvent` from being proxied

### DIFF
--- a/Classes/EventStore/RawEvent.php
+++ b/Classes/EventStore/RawEvent.php
@@ -11,12 +11,16 @@ namespace Neos\EventSourcing\EventStore;
  * source code.
  */
 
+use Neos\Flow\Annotations as Flow;
+
 /**
  * The raw event data including payload, metadata and technical meta information
  *
  * This class represents an event before it has been converted to an instance of EventInterface.
  * It is used by the EventStream which converts it on-the-fly and it will be passed to any when*() event listener
  * as optional argument.
+ *
+ * @Flow\Proxy(false)
  */
 final class RawEvent
 {


### PR DESCRIPTION
Adds a `@Flow\Proxy(false)` annotation to the `RawEvent` DTO
in order to make it serializable.