### PR TITLE
FEATURE: Expose `streamName` in `RawEvent`

### DIFF
--- a/Classes/EventStore/RawEvent.php
+++ b/Classes/EventStore/RawEvent.php
@@ -45,6 +45,11 @@ final class RawEvent
     private $metadata;
 
     /**
+     * @var string
+     */
+    private $streamName;
+
+    /**
      * @var int
      */
     private $version;
@@ -59,12 +64,13 @@ final class RawEvent
      */
     protected $recordedAt;
 
-    public function __construct(int $sequenceNumber, string $type, array $payload, array $metadata, int $version, string $identifier, \DateTimeInterface $recordedAt)
+    public function __construct(int $sequenceNumber, string $type, array $payload, array $metadata, string $streamName, int $version, string $identifier, \DateTimeInterface $recordedAt)
     {
         $this->sequenceNumber = $sequenceNumber;
         $this->type = $type;
         $this->payload = $payload;
         $this->metadata = $metadata;
+        $this->streamName = $streamName;
         $this->version = $version;
         $this->identifier = $identifier;
         $this->recordedAt = $recordedAt;
@@ -88,6 +94,11 @@ final class RawEvent
     public function getMetadata(): array
     {
         return $this->metadata;
+    }
+
+    public function getStreamName(): string
+    {
+        return $this->streamName;
     }
 
     public function getVersion(): int

--- a/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
+++ b/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
@@ -138,7 +138,7 @@ class DoctrineEventStorage implements EventStorageInterface
                 ]
             );
             $sequenceNumber = $this->connection->lastInsertId();
-            $rawEvents[] = new RawEvent($sequenceNumber, $event->getType(), $event->getData(), $metadata, $actualVersion, $event->getIdentifier(), $this->now);
+            $rawEvents[] = new RawEvent($sequenceNumber, $event->getType(), $event->getData(), $metadata, $streamName, $actualVersion, $event->getIdentifier(), $this->now);
         }
         $this->connection->commit();
         return $rawEvents;

--- a/Classes/EventStore/Storage/Doctrine/DoctrineStreamIterator.php
+++ b/Classes/EventStore/Storage/Doctrine/DoctrineStreamIterator.php
@@ -67,6 +67,7 @@ final class DoctrineStreamIterator implements \Iterator
             $currentEventData['type'],
             $payload,
             $metadata,
+            $currentEventData['stream'],
             (int)$currentEventData['version'],
             $currentEventData['id'],
             $recordedAt


### PR DESCRIPTION
Makes the `streamName` of a given event accessible via `RawEvent::getStreamName()`.
This can be useful for debugging purposes and is a precondition for #164

Related: #164