### PR TITLE
FEATURE: Allow fetching of single events

### DIFF
--- a/Classes/EventStore/EventStore.php
+++ b/Classes/EventStore/EventStore.php
@@ -12,6 +12,7 @@ namespace Neos\EventSourcing\EventStore;
  */
 
 use Neos\Error\Messages\Result;
+use Neos\EventSourcing\EventStore\Exception\EventNotFoundException;
 use Neos\EventSourcing\EventStore\Exception\EventStreamNotFoundException;
 use Neos\EventSourcing\EventStore\Storage\EventStorageInterface;
 
@@ -37,6 +38,8 @@ final class EventStore
     }
 
     /**
+     * Returns an EventStream that matches the given $filter - or throws an EventStreamNotFoundException if no matching events could be found
+     *
      * @param EventStreamFilterInterface $filter
      * @return EventStream Can be empty stream
      * @throws EventStreamNotFoundException
@@ -50,6 +53,22 @@ final class EventStore
             throw new EventStreamNotFoundException(sprintf('The event stream "%s" does not appear to be valid.', $streamName), 1477497156);
         }
         return $eventStream;
+    }
+
+    /**
+     * Returns the first EventAndRawEvent instance that matches the given $filter - or throws an EventNotFoundException if no matching events could be found
+     *
+     * @param EventStreamFilterInterface $filter
+     * @return EventAndRawEvent
+     * @throws EventNotFoundException
+     */
+    public function getOne(EventStreamFilterInterface $filter): EventAndRawEvent
+    {
+        $rawEvent = $this->storage->loadOne($filter);
+        if ($rawEvent === null) {
+            throw new EventNotFoundException('No event found for the given filter', 1513170518);
+        }
+        return (new EventStream(new \ArrayIterator([$rawEvent])))->current();
     }
 
     /**

--- a/Classes/EventStore/EventStreamFilterInterface.php
+++ b/Classes/EventStore/EventStreamFilterInterface.php
@@ -34,6 +34,11 @@ interface EventStreamFilterInterface
     const FILTER_MINIMUM_SEQUENCE_NUMBER = 'minimumSequenceNumber';
 
     /**
+     * integer with the version to be matched
+     */
+    const FILTER_VERSION = 'version';
+
+    /**
      * string representing the correlationIdentifier Metadata that has to match
      */
     const FILTER_CORRELATION_IDENTIFIER = 'correlationIdentifier';

--- a/Classes/EventStore/Exception/EventNotFoundException.php
+++ b/Classes/EventStore/Exception/EventNotFoundException.php
@@ -1,0 +1,18 @@
+<?php
+namespace Neos\EventSourcing\EventStore\Exception;
+
+/*
+ * This file is part of the Neos.EventSourcing package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\EventSourcing\RuntimeException;
+
+class EventNotFoundException extends RuntimeException
+{
+}

--- a/Classes/EventStore/RawEvent.php
+++ b/Classes/EventStore/RawEvent.php
@@ -45,6 +45,11 @@ final class RawEvent
     private $metadata;
 
     /**
+     * @var string
+     */
+    private $streamName;
+
+    /**
      * @var int
      */
     private $version;
@@ -59,12 +64,13 @@ final class RawEvent
      */
     protected $recordedAt;
 
-    public function __construct(int $sequenceNumber, string $type, array $payload, array $metadata, int $version, string $identifier, \DateTimeInterface $recordedAt)
+    public function __construct(int $sequenceNumber, string $type, array $payload, array $metadata, string $streamName, int $version, string $identifier, \DateTimeInterface $recordedAt)
     {
         $this->sequenceNumber = $sequenceNumber;
         $this->type = $type;
         $this->payload = $payload;
         $this->metadata = $metadata;
+        $this->streamName = $streamName;
         $this->version = $version;
         $this->identifier = $identifier;
         $this->recordedAt = $recordedAt;
@@ -88,6 +94,11 @@ final class RawEvent
     public function getMetadata(): array
     {
         return $this->metadata;
+    }
+
+    public function getStreamName(): string
+    {
+        return $this->streamName;
     }
 
     public function getVersion(): int

--- a/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
+++ b/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
@@ -138,7 +138,7 @@ class DoctrineEventStorage implements EventStorageInterface
                 ]
             );
             $sequenceNumber = $this->connection->lastInsertId();
-            $rawEvents[] = new RawEvent($sequenceNumber, $event->getType(), $event->getData(), $metadata, $actualVersion, $event->getIdentifier(), $this->now);
+            $rawEvents[] = new RawEvent($sequenceNumber, $event->getType(), $event->getData(), $metadata, $streamName, $actualVersion, $event->getIdentifier(), $this->now);
         }
         $this->connection->commit();
         return $rawEvents;

--- a/Classes/EventStore/Storage/Doctrine/DoctrineStreamIterator.php
+++ b/Classes/EventStore/Storage/Doctrine/DoctrineStreamIterator.php
@@ -67,6 +67,7 @@ final class DoctrineStreamIterator implements \Iterator
             $currentEventData['type'],
             $payload,
             $metadata,
+            $currentEventData['stream'],
             (int)$currentEventData['version'],
             $currentEventData['id'],
             $recordedAt

--- a/Classes/EventStore/Storage/EventStorageInterface.php
+++ b/Classes/EventStore/Storage/EventStorageInterface.php
@@ -30,6 +30,12 @@ interface EventStorageInterface
     public function load(EventStreamFilterInterface $filter): EventStream;
 
     /**
+     * @param EventStreamFilterInterface $filter
+     * @return RawEvent|null
+     */
+    public function loadOne(EventStreamFilterInterface $filter);
+
+    /**
      * @param string $streamName
      * @param WritableEvents $events
      * @param int $expectedVersion

--- a/Classes/EventStore/StreamNameAndVersionFilter.php
+++ b/Classes/EventStore/StreamNameAndVersionFilter.php
@@ -1,0 +1,78 @@
+<?php
+namespace Neos\EventSourcing\EventStore;
+
+/*
+ * This file is part of the Neos.EventSourcing package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\EventSourcing\Exception;
+
+/**
+ * Stream name and version filter
+ *
+ * This matches a single event in a stream
+ */
+class StreamNameAndVersionFilter implements EventStreamFilterInterface
+{
+    /**
+     * @var string
+     */
+    private $streamName;
+
+    /**
+     * @var int
+     */
+    private $version;
+
+    /**
+     * StreamNameAndVersionFilter constructor.
+     *
+     * @param string $streamName
+     * @param int $version
+     * @throws Exception
+     */
+    public function __construct(string $streamName, int $version)
+    {
+        $streamName = trim($streamName);
+        if ($streamName === '') {
+            throw new Exception('Empty stream filter provided', 1513170391);
+        }
+        if ($version < 0) {
+            throw new Exception('Negative version filter provided', 1513170397);
+        }
+        $this->streamName = $streamName;
+        $this->version = $version;
+    }
+
+    /**
+     * @return array
+     */
+    public function getFilterValues(): array
+    {
+        return [
+            self::FILTER_STREAM_NAME => $this->streamName,
+            self::FILTER_VERSION => $this->version,
+        ];
+    }
+
+    /**
+     * @param string $name
+     * @return mixed
+     */
+    public function getFilterValue(string $name)
+    {
+        switch ($name) {
+            case self::FILTER_STREAM_NAME:
+                return $this->streamName;
+            case self::FILTER_VERSION:
+                return $this->version;
+            break;
+        }
+    }
+}


### PR DESCRIPTION
This adds a new method `EventStore::getOne()` that allows
for fetching single events matching a given filter.

Besids this adds a new filter `StreamNameAndVersion` that
addresses a single event in a given stream.

Background:
This is the foundation to a more flexible & stable event handling
that enables the isolated processing of events in a separate
process.

Resolves: #164