### PR TITLE
FEATURE: Allow fetching of single events

### DIFF
--- a/Classes/EventStore/Exception/EventNotFoundException.php
+++ b/Classes/EventStore/Exception/EventNotFoundException.php
@@ -1,0 +1,18 @@
+<?php
+namespace Neos\EventSourcing\EventStore\Exception;
+
+/*
+ * This file is part of the Neos.EventSourcing package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\EventSourcing\RuntimeException;
+
+class EventNotFoundException extends RuntimeException
+{
+}

--- a/Classes/EventStore/Storage/EventStorageInterface.php
+++ b/Classes/EventStore/Storage/EventStorageInterface.php
@@ -30,6 +30,12 @@ interface EventStorageInterface
     public function load(EventStreamFilterInterface $filter): EventStream;
 
     /**
+     * @param string $eventIdentifier
+     * @return RawEvent|null
+     */
+    public function loadOne(string $eventIdentifier);
+
+    /**
      * @param string $streamName
      * @param WritableEvents $events
      * @param int $expectedVersion


### PR DESCRIPTION
This adds a new method `EventStore::getOne()` that allows
for fetching single events matching a given event identifier.

Background:

This is the foundation to a more flexible & stable event handling
that enables the isolated processing of events in a separate
process.

Resolves: #164