### PR TITLE
BUGFIX: Reconnect database connection if it timed out

### DIFF
--- a/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
+++ b/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
@@ -96,6 +96,7 @@ class DoctrineEventStorage implements EventStorageInterface
      */
     public function load(EventStreamFilterInterface $filter): EventStream
     {
+        $this->reconnectDatabaseConnection();
         $query = $this->connection->createQueryBuilder()
             ->select('*')
             ->from($this->eventTableName)
@@ -112,6 +113,7 @@ class DoctrineEventStorage implements EventStorageInterface
      */
     public function commit(string $streamName, WritableEvents $events, int $expectedVersion = ExpectedVersion::ANY): array
     {
+        $this->reconnectDatabaseConnection();
         $this->connection->beginTransaction();
         $actualVersion = $this->getStreamVersion(new StreamNameFilter($streamName));
         $this->verifyExpectedVersion($actualVersion, $expectedVersion);
@@ -327,5 +329,19 @@ class DoctrineEventStorage implements EventStorageInterface
         $table->addUniqueIndex(['stream', 'version'], 'stream_version_uniq');
 
         return $schema;
+    }
+
+    /**
+     * Reconnects the database connection associated with this storage, if it doesn't respond to a ping
+     *
+     * @see \Neos\Flow\Persistence\Doctrine\PersistenceManager::persistAll()
+     * @return void
+     */
+    private function reconnectDatabaseConnection()
+    {
+        if ($this->connection->ping() === false) {
+            $this->connection->close();
+            $this->connection->connect();
+        }
     }
 }

--- a/Classes/EventStore/Storage/Doctrine/DoctrineStreamIterator.php
+++ b/Classes/EventStore/Storage/Doctrine/DoctrineStreamIterator.php
@@ -143,5 +143,4 @@ final class DoctrineStreamIterator implements \Iterator
             $this->queryBuilder->getConnection()->connect();
         }
     }
-
 }

--- a/Classes/EventStore/Storage/Doctrine/DoctrineStreamIterator.php
+++ b/Classes/EventStore/Storage/Doctrine/DoctrineStreamIterator.php
@@ -125,7 +125,23 @@ final class DoctrineStreamIterator implements \Iterator
         // we deliberately don't use "setFirstResult" here, as this translates to an OFFSET query. For resolving
         // an OFFSET query, the DB needs to scan the result-set from the beginning (which is slow as hell).
         $this->queryBuilder->setParameter('sequenceNumberOffset', $this->currentOffset);
+        $this->reconnectDatabaseConnection();
         $rawResult = $this->queryBuilder->execute()->fetchAll();
         $this->innerIterator = new \ArrayIterator($rawResult);
     }
+
+    /**
+     * Reconnects the database connection associated with this storage, if it doesn't respond to a ping
+     *
+     * @see \Neos\Flow\Persistence\Doctrine\PersistenceManager::persistAll()
+     * @return void
+     */
+    private function reconnectDatabaseConnection()
+    {
+        if ($this->queryBuilder->getConnection()->ping() === false) {
+            $this->queryBuilder->getConnection()->close();
+            $this->queryBuilder->getConnection()->connect();
+        }
+    }
+
 }


### PR DESCRIPTION
Adds the `ping` => `close` => `connect` reconnection logic
(as suggested by Doctrine) to the `DoctrineEventStorage` to
prevent connection timeouts to occur for long running
processes.

Fixes: #171