### PR TITLE
BUGFIX: Remove protected flag from Package

### DIFF
--- a/Classes/Package.php
+++ b/Classes/Package.php
@@ -20,10 +20,6 @@ use Neos\Flow\Package\Package as BasePackage;
  */
 class Package extends BasePackage
 {
-    /**
-     * @var boolean
-     */
-    protected $protected = true;
 
     /**
      * @param Bootstrap $bootstrap The current bootstrap


### PR DESCRIPTION
This package was marked `protected` by accident (copy/paste).

Background:

Protected packages can't be deactivated or removed, but this
should not apply to the `Neos.EventSourcing` package