### PR TITLE
WIP: Centralized Event (de)serialization

### DIFF
--- a/Classes/Event/EventNormalizer.php
+++ b/Classes/Event/EventNormalizer.php
@@ -1,0 +1,57 @@
+<?php
+namespace Neos\EventSourcing\Event;
+
+/*
+ * This file is part of the Neos.EventSourcing package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Serializer\Normalizer\JsonSerializableNormalizer;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer;
+
+/**
+ * @Flow\Scope("singleton")
+ *
+ * Converts instances of EventInterface to serializable arrays vice versa
+ */
+final class EventNormalizer
+{
+
+    /**
+     * @Flow\Inject
+     * @var EventTypeResolver
+     */
+    protected $eventTypeResolver;
+
+    /**
+     * @var Serializer
+     */
+    private $serializer;
+
+    protected function initializeObject(): void
+    {
+        // TODO: make normalizers configurable
+        $normalizers = [new DateTimeNormalizer(\DateTime::ISO8601), new JsonSerializableNormalizer(), new ObjectNormalizer()];
+        $this->serializer = new Serializer($normalizers);
+    }
+
+    public function normalize(EventInterface $event): array
+    {
+        return $this->serializer->normalize($event);
+    }
+
+    public function denormalize(array $eventData, string $eventType): EventInterface
+    {
+        // TODO allow to hook into event type => class conversion in order to enable upcasting, ...
+        $eventClassName = $this->eventTypeResolver->getEventClassNameByType($eventType);
+        return $this->serializer->denormalize($eventData, $eventClassName);
+    }
+}

--- a/Classes/EventStore/EventStream.php
+++ b/Classes/EventStore/EventStream.php
@@ -11,27 +11,20 @@ namespace Neos\EventSourcing\EventStore;
  * source code.
  */
 
-use Neos\EventSourcing\Event\EventTypeResolver;
-use Neos\EventSourcing\Property\AllowAllPropertiesPropertyMappingConfiguration;
+use Neos\EventSourcing\Event\EventNormalizer;
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\Property\PropertyMapper;
 
 /**
  * EventStream
  */
 final class EventStream implements \Iterator
 {
-    /**
-     * @Flow\Inject
-     * @var EventTypeResolver
-     */
-    protected $eventTypeResolver;
 
     /**
      * @Flow\Inject
-     * @var PropertyMapper
+     * @var EventNormalizer
      */
-    protected $propertyMapper;
+    protected $eventNormalizer;
 
     /**
      * @var \Iterator
@@ -51,13 +44,10 @@ final class EventStream implements \Iterator
      */
     public function current()
     {
-        $configuration = new AllowAllPropertiesPropertyMappingConfiguration();
-
         /** @var RawEvent $rawEvent */
         $rawEvent = $this->streamIterator->current();
-        $eventClassName = $this->eventTypeResolver->getEventClassNameByType($rawEvent->getType());
         return new EventAndRawEvent(
-            $this->propertyMapper->convert($rawEvent->getPayload(), $eventClassName, $configuration),
+            $this->eventNormalizer->denormalize($rawEvent->getPayload(), $rawEvent->getType()),
             $rawEvent
         );
     }

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,9 @@
     "description": "Lean and opinionated way to integrate Event Sourcing and CQRS pattern in your Flow framework package",
     "require": {
         "php": ">=7.0",
-        "neos/flow": "~4.0 || ~5.0 || dev-master"
+        "neos/flow": "~4.0 || ~5.0 || dev-master",
+        "symfony/serializer": "^4.1",
+        "symfony/property-access": "^4.1"
     },
     "suggest": {
         "php-uuid": "For fast generation of UUIDs used in the persistence."


### PR DESCRIPTION
Replaces the `PropertyMapper` by the Symfony serializer
introducing a central `EventNormalizer` class

Resolves: #169