### PR TITLE
TASK: Change format for DateTimeInterface values to match `DateTimeConverter`

### DIFF
--- a/Classes/TypeConverter/EventToArrayConverter.php
+++ b/Classes/TypeConverter/EventToArrayConverter.php
@@ -67,7 +67,7 @@ class EventToArrayConverter extends AbstractTypeConverter
             if ($propertyValue instanceof \DateTimeZone) {
                 $propertyValue = $propertyValue->getName();
             } elseif ($propertyValue instanceof \DateTimeInterface) {
-                $propertyValue = $propertyValue->format(DATE_ISO8601);
+                $propertyValue = $propertyValue->format(\DateTime::W3C);
             } elseif (is_object($propertyValue)) {
                 $propertyValue = $this->convertObject($propertyValue);
             }


### PR DESCRIPTION
PHP's DATE_ISO8601 is defined as `"Y-m-d\\TH:i:sO"` while for converting a value to DateTime object, the Flow DateTimeConverter expects `\DateTime::W3C` by default, which uses the more widely accepted and used `"Y-m-d\TH:i:sP"`.

See http://php.net/manual/en/class.datetimeinterface.php#datetime.constants.iso8601 (Note that ATOM is the same as W3C)
See https://github.com/neos/flow-development-collection/blob/master/Neos.Flow/Classes/Property/TypeConverter/DateTimeConverter.php#L75

Related to #181