### PR TITLE
TASK: Use correct typehint for doctrine EntityManager

### DIFF
--- a/Classes/Projection/Doctrine/DoctrineProjectionPersistenceManager.php
+++ b/Classes/Projection/Doctrine/DoctrineProjectionPersistenceManager.php
@@ -11,7 +11,6 @@ namespace Neos\EventSourcing\Projection\Doctrine;
  * source code.
  */
 
-use Doctrine\Common\Persistence\ObjectManager as DoctrineObjectManager;
 use Doctrine\ORM\EntityManager as DoctrineEntityManager;
 use Doctrine\ORM\ORMException;
 use Doctrine\ORM\UnitOfWork;
@@ -45,10 +44,10 @@ class DoctrineProjectionPersistenceManager
     private $numberOfPendingChanges = 0;
 
     /**
-     * @param DoctrineObjectManager $entityManager
+     * @param DoctrineEntityManager $entityManager
      * @return void
      */
-    public function injectEntityManager(DoctrineObjectManager $entityManager)
+    public function injectEntityManager(DoctrineEntityManager $entityManager)
     {
         $this->entityManager = $entityManager;
     }


### PR DESCRIPTION
DoctrineEntityManager was already used for the property typehint. The `ObjectManager` is deprecated though and should be replaced with `EntityManagerInterface`.

See https://github.com/neos/flow-development-collection/pull/1272