### PR TITLE
TASK: Refactor AppliedEventsLogRepository initialization

### DIFF
--- a/Classes/EventBus/EventBus.php
+++ b/Classes/EventBus/EventBus.php
@@ -60,7 +60,9 @@ final class EventBus
 
     public function flush(): void
     {
-        $this->appliedEventsLogRepository->ensureHighestAppliedSequenceNumbersAreInitialized();
+        foreach (array_keys($this->pendingEventListenerClassNames) as $listenerClassName) {
+            $this->appliedEventsLogRepository->initializeHighestAppliedSequenceNumber($listenerClassName);
+        }
 
         foreach (array_keys($this->pendingEventListenerClassNames) as $listenerClassName) {
             $job = new CatchUpEventListenerJob($listenerClassName);

--- a/Classes/EventListener/AppliedEventsLogRepository.php
+++ b/Classes/EventListener/AppliedEventsLogRepository.php
@@ -20,8 +20,6 @@ use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\ORM\EntityManager as DoctrineEntityManager;
 use Neos\EventSourcing\EventListener\Exception\HighestAppliedSequenceNumberCantBeReservedException;
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\ObjectManagement\ObjectManagerInterface;
-use Neos\Flow\Reflection\ReflectionService;
 
 /**
  * TODO Document
@@ -39,23 +37,39 @@ class AppliedEventsLogRepository
     private $dbal;
 
     /**
-     * @var ObjectManagerInterface
-     */
-    protected $objectManager;
-
-    /**
      * @param DoctrineObjectManager $entityManager
-     * @param ObjectManagerInterface $objectManager
      *
      * // TODO use EventStore DBAL connection (?)
      */
-    public function __construct(DoctrineObjectManager $entityManager, ObjectManagerInterface $objectManager)
+    public function __construct(DoctrineObjectManager $entityManager)
     {
         if (!$entityManager instanceof DoctrineEntityManager) {
             throw new \RuntimeException(sprintf('The injected entityManager is expected to be an instance of "%s". Given: "%s"', DoctrineEntityManager::class, get_class($entityManager)), 1521556748);
         }
         $this->dbal = $entityManager->getConnection();
-        $this->objectManager = $objectManager;
+    }
+
+
+    /**
+     * This method should be called BEFORE the Projection Workers are actually started; as otherwise,
+     * inserting into the AppliedEventsLog might lead to a deadlock when multiple workers want to insert
+     * the "-1" default event IDs.
+     *
+     * That's why this preparation is executed in the EventBus; BEFORE dispatching to the different Jobs.
+     * It's a form of "HELPING", where the main (web) process helps the projection processes to have a known entry in the AppliedEventsLog.
+     *
+     * @param string $eventListenerIdentifier
+     * @throws DBALException
+     */
+    public function initializeHighestAppliedSequenceNumber(string $eventListenerIdentifier): void
+    {
+        if ($this->dbal->getTransactionNestingLevel() !== 0) {
+            throw new \RuntimeException('initializeHighestAppliedSequenceNumber only works not inside a transaction.', 1551005203);
+        }
+
+        $this->dbal->executeUpdate('INSERT IGNORE INTO ' . self::TABLE_NAME . ' (eventListenerIdentifier, highestAppliedSequenceNumber) VALUES (:eventListenerIdentifier, -1)',
+            ['eventListenerIdentifier' => $eventListenerIdentifier]
+        );
     }
 
     public function reserveHighestAppliedEventSequenceNumber(string $eventListenerIdentifier): int
@@ -94,7 +108,7 @@ class AppliedEventsLogRepository
             throw new \RuntimeException($exception->getMessage(), 1544207778, $exception);
         }
         if ($highestAppliedSequenceNumber === false) {
-            throw new HighestAppliedSequenceNumberCantBeReservedException(sprintf('Could not reserve highest applied sequence number for listener "%s", because the corresponding row was not found in the neos_eventsourcing_eventlistener_appliedeventslog table. This means the method ensureHighestAppliedSequenceNumbersAreInitialized() was not called beforehand.', $eventListenerIdentifier), 1550948433);
+            throw new HighestAppliedSequenceNumberCantBeReservedException(sprintf('Could not reserve highest applied sequence number for listener "%s", because the corresponding row was not found in the %s table. This means the method initializeHighestAppliedSequenceNumber() was not called beforehand.', $eventListenerIdentifier, self::TABLE_NAME), 1550948433);
         }
         return (int)$highestAppliedSequenceNumber;
     }
@@ -109,7 +123,7 @@ class AppliedEventsLogRepository
 
     public function saveHighestAppliedSequenceNumber(string $eventListenerIdentifier, int $sequenceNumber): void
     {
-        // Fails if no matching entry exists; which is fine because ensureHighestAppliedSequenceNumbersAreInitialized() must be called beforehand.
+        // Fails if no matching entry exists; which is fine because initializeHighestAppliedSequenceNumber() must be called beforehand.
         try {
             $this->dbal->update(
                 self::TABLE_NAME,
@@ -117,7 +131,7 @@ class AppliedEventsLogRepository
                 ['eventListenerIdentifier' => $eventListenerIdentifier]
             );
         } catch (DBALException $exception) {
-            throw new \RuntimeException(sprintf('Could not save highest applied sequence number for listener "%s". Did you call ensureHighestAppliedSequenceNumbersAreInitialized() beforehand?', $eventListenerIdentifier), 1544207099, $exception);
+            throw new \RuntimeException(sprintf('Could not save highest applied sequence number for listener "%s". Did you call initializeHighestAppliedSequenceNumber() beforehand?', $eventListenerIdentifier), 1544207099, $exception);
         }
     }
 
@@ -136,44 +150,5 @@ class AppliedEventsLogRepository
         } catch (DBALException $exception) {
             throw new \RuntimeException(sprintf('Could not reset highest applied sequence number for listener "%s"', $eventListenerIdentifier), 1544213138, $exception);
         }
-    }
-
-    /**
-     * This method should be called BEFORE the Projection Workers are actually started; as otherwise,
-     * inserting into the AppliedEventsLog might lead to a deadlock when multiple workers want to insert
-     * the "-1" default event IDs.
-     *
-     * That's why this preparation is executed in the EventBus; BEFORE dispatching to the different Jobs.
-     * It's a form of "HELPING", where the main (web) process helps the projection processes to have a known entry in the AppliedEventsLog.
-     */
-    public function ensureHighestAppliedSequenceNumbersAreInitialized()
-    {
-        if ($this->dbal->getTransactionNestingLevel() !== 0) {
-            throw new \RuntimeException('ensureHighestAppliedSequenceNumbersAreInitialized only works not inside a transaction.');
-        }
-
-        $this->dbal->transactional(function () {
-            foreach (self::getAllEventListeners($this->objectManager) as $eventListenerIdentifier) {
-                // HINT: we do a "INSERT IGNORE" here, meaning "if the primary key (eventListenerIdentifier) already exists, the insert is not done".
-                // Which is exactly what we want; "only insert "-1" if no value existed yet.
-                $this->dbal->executeUpdate('INSERT IGNORE INTO ' . self::TABLE_NAME . ' (eventListenerIdentifier, highestAppliedSequenceNumber) VALUES (:eventListenerIdentifier, -1)',
-                    ['eventListenerIdentifier' => $eventListenerIdentifier]
-                );
-            }
-        });
-    }
-
-    /**
-     * Create mapping between Event class name and Event type
-     *
-     * @param ObjectManagerInterface $objectManager
-     * @return array
-     * @Flow\CompileStatic
-     */
-    protected static function getAllEventListeners(ObjectManagerInterface $objectManager): array
-    {
-        /** @var ReflectionService $reflectionService */
-        $reflectionService = $objectManager->get(ReflectionService::class);
-        return $reflectionService->getAllImplementationClassNamesForInterface(EventListenerInterface::class);
     }
 }

--- a/Classes/Projection/ProjectionManager.php
+++ b/Classes/Projection/ProjectionManager.php
@@ -125,7 +125,7 @@ class ProjectionManager
         $projector = $this->objectManager->get($projection->getProjectorClassName());
         $this->appliedEventsLogRepository->removeHighestAppliedSequenceNumber($projection->getProjectorClassName());
         $projector->reset();
-        $this->appliedEventsLogRepository->ensureHighestAppliedSequenceNumbersAreInitialized();
+        $this->appliedEventsLogRepository->initializeHighestAppliedSequenceNumber($projection->getProjectorClassName());
         $this->eventListenerInvoker->catchUp($projector, $progressCallback);
     }
 


### PR DESCRIPTION
Replaces `ensureHighestAppliedSequenceNumbersAreInitialized()` by a method
`initializeHighestAppliedSequenceNumber()` that has to be called per listener
in order to inverse dependencies