### PR TITLE
BUGFIX: Fix normalization for integer, boolean and float based value objects

### DIFF
--- a/Tests/Unit/EventStore/Normalizer/Fixture/ArrayBasedValueObject.php
+++ b/Tests/Unit/EventStore/Normalizer/Fixture/ArrayBasedValueObject.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\EventSourcing\Tests\Unit\EventStore\Normalizer\Fixture;
+
+class ArrayBasedValueObject
+{
+    public static function fromArray(array $value): self
+    {
+        return new self();
+    }
+}

--- a/Tests/Unit/EventStore/Normalizer/Fixture/BooleanBasedValueObject.php
+++ b/Tests/Unit/EventStore/Normalizer/Fixture/BooleanBasedValueObject.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\EventSourcing\Tests\Unit\EventStore\Normalizer\Fixture;
+
+class BooleanBasedValueObject
+{
+    public static function fromBoolean(bool $value): self
+    {
+        return new self();
+    }
+}

--- a/Tests/Unit/EventStore/Normalizer/Fixture/FloatBasedValueObject.php
+++ b/Tests/Unit/EventStore/Normalizer/Fixture/FloatBasedValueObject.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\EventSourcing\Tests\Unit\EventStore\Normalizer\Fixture;
+
+class FloatBasedValueObject
+{
+    public static function fromFloat(float $value): self
+    {
+        return new self();
+    }
+}

--- a/Tests/Unit/EventStore/Normalizer/Fixture/IntegerBasedValueObject.php
+++ b/Tests/Unit/EventStore/Normalizer/Fixture/IntegerBasedValueObject.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\EventSourcing\Tests\Unit\EventStore\Normalizer\Fixture;
+
+class IntegerBasedValueObject
+{
+    public static function fromInteger(int $value): self
+    {
+        return new self();
+    }
+}

--- a/Tests/Unit/EventStore/Normalizer/Fixture/StringBasedValueObject.php
+++ b/Tests/Unit/EventStore/Normalizer/Fixture/StringBasedValueObject.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\EventSourcing\Tests\Unit\EventStore\Normalizer\Fixture;
+
+class StringBasedValueObject
+{
+    public static function fromString(string $value): self
+    {
+        return new self();
+    }
+}

--- a/Tests/Unit/EventStore/Normalizer/ValueObjectNormalizerTest.php
+++ b/Tests/Unit/EventStore/Normalizer/ValueObjectNormalizerTest.php
@@ -12,7 +12,7 @@ class ValueObjectNormalizerTest extends UnitTestCase
      * @test
      * @dataProvider provideSourceDataAndClassNames
      */
-    public function ValueObjectNormalizer_supports_denormalization_of($sourceData, string $className): void
+    public function supportsDenormalizationTests($sourceData, string $className): void
     {
         $normalizer = new ValueObjectNormalizer();
         $this->assertTrue(
@@ -24,7 +24,7 @@ class ValueObjectNormalizerTest extends UnitTestCase
      * @test
      * @dataProvider provideSourceDataAndClassNames
      */
-    public function ValueObjectNormalizer_creates_instances_of_a_given_type($sourceData, string $className): void
+    public function denormalizeTests($sourceData, string $className): void
     {
         $normalizer = new ValueObjectNormalizer();
         $this->assertInstanceOf(
@@ -35,50 +35,10 @@ class ValueObjectNormalizerTest extends UnitTestCase
 
     public function provideSourceDataAndClassNames()
     {
-        yield 'integer' => [0, IntegerBasedValueObject::class];
-        yield 'string' => ['', StringBasedValueObject::class];
-        yield 'boolean' => [true, BooleanBasedValueObject::class];
-        yield 'float' => [0.0, FloatBasedValueObject::class];
-        yield 'array' => [[], ArrayBasedValueObject::class];
-    }
-}
-
-class IntegerBasedValueObject
-{
-    public static function fromInteger(int $value): self
-    {
-        return new self();
-    }
-}
-
-class StringBasedValueObject
-{
-    public static function fromString(string $value): self
-    {
-        return new self();
-    }
-}
-
-class BooleanBasedValueObject
-{
-    public static function fromBoolean(bool $value): self
-    {
-        return new self();
-    }
-}
-
-class FloatBasedValueObject
-{
-    public static function fromFloat(float $value): self
-    {
-        return new self();
-    }
-}
-
-class ArrayBasedValueObject
-{
-    public static function fromArray(array $value): self
-    {
-        return new self();
+        yield 'integer' => [0, Fixture\IntegerBasedValueObject::class];
+        yield 'string' => ['', Fixture\StringBasedValueObject::class];
+        yield 'boolean' => [true, Fixture\BooleanBasedValueObject::class];
+        yield 'float' => [0.0, Fixture\FloatBasedValueObject::class];
+        yield 'array' => [[], Fixture\ArrayBasedValueObject::class];
     }
 }

--- a/Tests/Unit/EventStore/Normalizer/ValueObjectNormalizerTest.php
+++ b/Tests/Unit/EventStore/Normalizer/ValueObjectNormalizerTest.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\EventSourcing\Tests\Unit\EventStore\Normalizer;
+
+use Neos\EventSourcing\EventStore\Normalizer\ValueObjectNormalizer;
+use Neos\Flow\Tests\UnitTestCase;
+
+class ValueObjectNormalizerTest extends UnitTestCase
+{
+    /**
+     * @test
+     * @dataProvider provideSourceDataAndClassNames
+     */
+    public function ValueObjectNormalizer_supports_denormalization_of($sourceData, string $className): void
+    {
+        $normalizer = new ValueObjectNormalizer();
+        $this->assertTrue(
+            $normalizer->supportsDenormalization($sourceData, $className)
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider provideSourceDataAndClassNames
+     */
+    public function ValueObjectNormalizer_creates_instances_of_a_given_type($sourceData, string $className): void
+    {
+        $normalizer = new ValueObjectNormalizer();
+        $this->assertInstanceOf(
+            $className,
+            $normalizer->denormalize($sourceData, $className)
+        );
+    }
+
+    public function provideSourceDataAndClassNames()
+    {
+        yield 'integer' => [0, IntegerBasedValueObject::class];
+        yield 'string' => ['', StringBasedValueObject::class];
+        yield 'boolean' => [true, BooleanBasedValueObject::class];
+        yield 'float' => [0.0, FloatBasedValueObject::class];
+        yield 'array' => [[], ArrayBasedValueObject::class];
+    }
+}
+
+class IntegerBasedValueObject
+{
+    public static function fromInteger(int $value): self
+    {
+        return new self();
+    }
+}
+
+class StringBasedValueObject
+{
+    public static function fromString(string $value): self
+    {
+        return new self();
+    }
+}
+
+class BooleanBasedValueObject
+{
+    public static function fromBoolean(bool $value): self
+    {
+        return new self();
+    }
+}
+
+class FloatBasedValueObject
+{
+    public static function fromFloat(float $value): self
+    {
+        return new self();
+    }
+}
+
+class ArrayBasedValueObject
+{
+    public static function fromArray(array $value): self
+    {
+        return new self();
+    }
+}


### PR DESCRIPTION
When it comes to "int", "bool" and "float" there's a missmatch between
the PHP `gettype()`  method result and the reflection property type.
One results "integer, boolean, double", the other "int, bool, float".

Those named constructor arguments are supported:

```
IntegerBasedValueObject::fromInteger(int $value): self
StringBasedValueObject::fromString(string $value): self
BooleanBasedValueObject::fromBoolean(bool $value): self
FloatBasedValueObject::fromFloat(float $value): self
ArrayBasedValueObject::fromArray(array $value): self
```

Related: https://github.com/neos/Neos.EventSourcing/issues/210