### PR TITLE
BUGFIX: Stabilize EventStoreManager::getEventStoreForEventListener()

### DIFF
--- a/Classes/EventStore/EventStoreManager.php
+++ b/Classes/EventStore/EventStoreManager.php
@@ -146,7 +146,10 @@ final class EventStoreManager
      */
     public function getEventStoreForEventListener(string $listenerClassName): EventStore
     {
-        $boundedContext = $this->objectManager->getPackageKeyByObjectName($listenerClassName) ?? '';
+        $boundedContext = $this->objectManager->getPackageKeyByObjectName($listenerClassName);
+        if ($boundedContext === false) {
+            $boundedContext = '';
+        }
         return $this->getEventStoreForBoundedContext($boundedContext);
     }
 


### PR DESCRIPTION
Fixes `EventStoreManager::getEventStoreForEventListener()` to return
the default Event Store instance if the package could not be determined