### PR TITLE
FEATURE: Allow default EventStore to be injected

### DIFF
--- a/Classes/EventStore/EventStoreManager.php
+++ b/Classes/EventStore/EventStoreManager.php
@@ -19,7 +19,7 @@ use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 
 /**
  * The Event Store manager is responsible for building and Event Store instances as configured.
- * Whenever an Event Store is needed, it should be retrieved through this class.
+ * It is used as factory for the EventStore but can also be used explicitly when a certain event store instance is required.
  *
  * @Flow\Scope("singleton")
  */
@@ -77,6 +77,7 @@ final class EventStoreManager
             if (!isset($eventStoreConfiguration['boundedContexts']) || empty($eventStoreConfiguration['boundedContexts'])) {
                 throw new StorageConfigurationException(sprintf('The Event Store "%s" has no Bounded Context assigned. Please configure some.', $eventStoreIdentifier), 1479213813);
             }
+            /** @noinspection ForeachSourceInspection */
             foreach ($eventStoreConfiguration['boundedContexts'] as $boundedContext => $isActive) {
                 if (!$isActive) {
                     continue;
@@ -120,9 +121,7 @@ final class EventStoreManager
         if (!$storageInstance instanceof EventStorageInterface) {
             throw new StorageConfigurationException(sprintf('The configured Storage for Event Store "%s" does not implement the EventStorageInterface', $eventStoreIdentifier), 1492610908);
         }
-        /** @noinspection PhpMethodParametersCountMismatchInspection */
-        $this->initializedEventStores[$eventStoreIdentifier] = $this->objectManager->get(EventStore::class, $storageInstance);
-
+        $this->initializedEventStores[$eventStoreIdentifier] = new EventStore($storageInstance);
         return $this->initializedEventStores[$eventStoreIdentifier];
     }
 

--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -2,3 +2,10 @@ Neos\EventSourcing\EventStore\EventStoreManager:
   arguments:
     2:
       setting: 'Neos.EventSourcing.EventStore.stores'
+
+Neos\EventSourcing\EventStore\EventStore:
+  factoryObjectName: Neos\EventSourcing\EventStore\EventStoreManager
+  factoryMethodName: getEventStore
+  arguments:
+    1:
+      value: 'default'


### PR DESCRIPTION
To simplify basic usage this change introduces a basic `Objects.yaml`
configuration that allows for injecting the configured "default" `EventStore`
without having to use the `EventStoreManager`.

Usage:

```php
<?php

// ...

    /**
     * @Flow\Inject
     * @var EventStore
     */
    protected $eventStore;
```

This change is fully backwards compatible as the `EventStoreManager` can still
be used to get hold of a specific Event Store instance (for now).

And obviously one can rewire the automatic injection via some custom `Objects.yaml` like:

```yaml
Some\Package\Some\Class:
  properties:
    'eventStore':
      object:
        factoryObjectName: Neos\EventSourcing\EventStore\EventStoreManager
        factoryMethodName: getEventStore
        arguments:
          1:
            value: 'some-other-event-store'
```

Related: #212