### PR TITLE
!!! BUGFIX: Fix (de)normalization for array based classes

### DIFF
--- a/Classes/EventStore/EventNormalizer.php
+++ b/Classes/EventStore/EventNormalizer.php
@@ -40,7 +40,7 @@ final class EventNormalizer
      */
     private $serializer;
 
-    protected function initializeObject(): void
+    public function __construct()
     {
         // TODO: make normalizers configurable
         $normalizers = [new DateTimeNormalizer(), new JsonSerializableNormalizer(), new ValueObjectNormalizer(), new ProxyAwareObjectNormalizer()];

--- a/Classes/EventStore/Normalizer/ValueObjectNormalizer.php
+++ b/Classes/EventStore/Normalizer/ValueObjectNormalizer.php
@@ -2,9 +2,9 @@
 declare(strict_types=1);
 namespace Neos\EventSourcing\EventStore\Normalizer;
 
+use Neos\Flow\ObjectManagement\Proxy\ProxyInterface;
 use Neos\Utility\TypeHandling;
 use ReflectionMethod;
-use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 /**
@@ -56,7 +56,11 @@ final class ValueObjectNormalizer implements DenormalizerInterface
         if ($dataType === 'array' && $namedConstructorMethod === null) {
             throw new \InvalidArgumentException(sprintf('Missing named constructor static public function fromArray(array $foo): self in class "%s"', $className), 1569500780);
         }
-        $constructorMethod = $namedConstructorMethod ?? $reflectionClass->getConstructor();
+        if ($namedConstructorMethod !== null) {
+            $constructorMethod = $namedConstructorMethod;
+        } else {
+            $constructorMethod = $reflectionClass->implementsInterface(ProxyInterface::class) ? $reflectionClass->getParentClass()->getConstructor() : $reflectionClass->getConstructor();
+        }
         if ($constructorMethod === null) {
             throw new \InvalidArgumentException(sprintf('Could not resolve constructor for class "%s"', $className), 1545233397);
         }

--- a/Tests/Functional/EventStore/EventNormalizerTest.php
+++ b/Tests/Functional/EventStore/EventNormalizerTest.php
@@ -8,6 +8,8 @@ use Neos\EventSourcing\Event\EventTypeResolver;
 use Neos\EventSourcing\EventStore\EventNormalizer;
 use Neos\EventSourcing\Tests\Functional\EventStore\Fixture\MockDomainEvent;
 use Neos\EventSourcing\Tests\Functional\EventStore\Fixture\MockDomainEvent2;
+use Neos\EventSourcing\Tests\Functional\EventStore\Fixture\MockDomainEvent3;
+use Neos\EventSourcing\Tests\Functional\EventStore\Fixture\MockValueObject;
 use Neos\Flow\Tests\FunctionalTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -49,6 +51,7 @@ class EventNormalizerTest extends FunctionalTestCase
     {
         yield [MockDomainEvent::class, ['string' => 'Some String'], new MockDomainEvent('Some String')];
         yield [MockDomainEvent2::class, ['string' => 'Some Other String'], new MockDomainEvent2('Some Other String')];
+        yield [MockDomainEvent3::class, ['value' => 'Yet another String'], new MockDomainEvent3(new MockValueObject('Yet another String'))];
     }
 
     /**
@@ -67,6 +70,7 @@ class EventNormalizerTest extends FunctionalTestCase
     {
         yield [new MockDomainEvent('foo'), ['string' => 'foo']];
         yield [new MockDomainEvent2('bar'), ['string' => 'bar']];
+        yield [new MockDomainEvent3(new MockValueObject('baz')), ['value' => 'baz']];
     }
 
 }

--- a/Tests/Functional/EventStore/Fixture/MockDomainEvent3.php
+++ b/Tests/Functional/EventStore/Fixture/MockDomainEvent3.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\EventSourcing\Tests\Functional\EventStore\Fixture;
+
+use Neos\EventSourcing\Event\DomainEventInterface;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * @Flow\Proxy(false)
+ */
+final class MockDomainEvent3 implements DomainEventInterface
+{
+    /**
+     * @var string
+     */
+    private $value;
+
+    public function __construct(MockValueObject $value)
+    {
+        $this->value = $value;
+    }
+
+    public function getValue(): MockValueObject
+    {
+        return $this->value;
+    }
+
+}

--- a/Tests/Functional/EventStore/Fixture/MockValueObject.php
+++ b/Tests/Functional/EventStore/Fixture/MockValueObject.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\EventSourcing\Tests\Functional\EventStore\Fixture;
+
+final class MockValueObject implements \JsonSerializable
+{
+    /**
+     * @var string
+     */
+    private $string;
+
+    public function __construct(string $string)
+    {
+        $this->string = $string;
+    }
+
+    public function getString(): string
+    {
+        return $this->string;
+    }
+
+    public function jsonSerialize(): string
+    {
+        return $this->string;
+    }
+}

--- a/Tests/Unit/EventStore/EventNormalizerTest.php
+++ b/Tests/Unit/EventStore/EventNormalizerTest.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+namespace Neos\EventSourcing\Tests\Unit\EventStore;
+
+use Neos\EventSourcing\Event\EventTypeResolver;
+use Neos\EventSourcing\EventStore\EventNormalizer;
+use Neos\Flow\Tests\UnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class EventNormalizerTest extends UnitTestCase
+{
+
+    /**
+     * @var EventNormalizer
+     */
+    private $eventNormalizer;
+
+    /**
+     * @var EventTypeResolver|MockObject
+     */
+    private $mockEventTypeResolver;
+
+    public function setUp(): void
+    {
+        $this->eventNormalizer = new EventNormalizer();
+        $this->mockEventTypeResolver = $this->getMockBuilder(EventTypeResolver::class)->disableOriginalConstructor()->getMock();
+        $this->inject($this->eventNormalizer, 'eventTypeResolver', $this->mockEventTypeResolver);
+    }
+
+    /**
+     * @test
+     */
+    public function normalizeExtractsPayloadFromArrayBasedEvent(): void
+    {
+        $mockData = ['some' => 'data'];
+        $event = new Fixture\ArrayBasedEvent($mockData);
+        $result = $this->eventNormalizer->normalize($event);
+        self::assertSame(['data' => $mockData], $result);
+    }
+
+    /**
+     * see https://github.com/neos/Neos.EventSourcing/issues/233
+     *
+     * @test
+     */
+    public function denormalizeConstructsArrayBasedEventWithCorrectPayload(): void
+    {
+        $mockData = ['some' => 'data'];
+        $normalizedEvent = ['data' => $mockData];
+
+        $this->mockEventTypeResolver->method('getEventClassNameByType')->with('Some.Event:Type')->willReturn(Fixture\ArrayBasedEvent::class);
+
+        /** @var Fixture\ArrayBasedEvent $event */
+        $event = $this->eventNormalizer->denormalize($normalizedEvent, 'Some.Event:Type');
+        self::assertSame($mockData, $event->getData());
+    }
+}

--- a/Tests/Unit/EventStore/Fixture/ArrayBasedEvent.php
+++ b/Tests/Unit/EventStore/Fixture/ArrayBasedEvent.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\EventSourcing\Tests\Unit\EventStore\Fixture;
+
+use Neos\EventSourcing\Event\DomainEventInterface;
+
+final class ArrayBasedEvent implements DomainEventInterface
+{
+    /**
+     * @var array
+     */
+    private $data;
+
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+}

--- a/Tests/Unit/EventStore/Normalizer/Fixture/InvalidArrayBasedValueObject.php
+++ b/Tests/Unit/EventStore/Normalizer/Fixture/InvalidArrayBasedValueObject.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\EventSourcing\Tests\Unit\EventStore\Normalizer\Fixture;
+
+/**
+ * see https://github.com/neos/Neos.EventSourcing/issues/233
+ */
+class InvalidArrayBasedValueObject
+{
+    public function __construct(array $value)
+    {
+    }
+}

--- a/Tests/Unit/EventStore/Normalizer/ValueObjectNormalizerTest.php
+++ b/Tests/Unit/EventStore/Normalizer/ValueObjectNormalizerTest.php
@@ -9,14 +9,23 @@ use Neos\Flow\Tests\UnitTestCase;
 class ValueObjectNormalizerTest extends UnitTestCase
 {
     /**
+     * @var ValueObjectNormalizer
+     */
+    private $valueObjectNormalizer;
+
+    public function setUp(): void
+    {
+        $this->valueObjectNormalizer = new ValueObjectNormalizer();
+    }
+
+    /**
      * @test
      * @dataProvider provideSourceDataAndClassNames
      */
     public function supportsDenormalizationTests($sourceData, string $className): void
     {
-        $normalizer = new ValueObjectNormalizer();
         $this->assertTrue(
-            $normalizer->supportsDenormalization($sourceData, $className)
+            $this->valueObjectNormalizer->supportsDenormalization($sourceData, $className)
         );
     }
 
@@ -26,10 +35,9 @@ class ValueObjectNormalizerTest extends UnitTestCase
      */
     public function denormalizeTests($sourceData, string $className): void
     {
-        $normalizer = new ValueObjectNormalizer();
         $this->assertInstanceOf(
             $className,
-            $normalizer->denormalize($sourceData, $className)
+            $this->valueObjectNormalizer->denormalize($sourceData, $className)
         );
     }
 
@@ -40,5 +48,22 @@ class ValueObjectNormalizerTest extends UnitTestCase
         yield 'boolean' => [true, Fixture\BooleanBasedValueObject::class];
         yield 'float' => [0.0, Fixture\FloatBasedValueObject::class];
         yield 'array' => [[], Fixture\ArrayBasedValueObject::class];
+    }
+
+    /**
+     * @test
+     */
+    public function supportsDenormalizationReturnsFalseForArrayValueObjectsWithoutNamedConstructor(): void
+    {
+        self::assertFalse($this->valueObjectNormalizer->supportsDenormalization(['some' => 'array'], Fixture\InvalidArrayBasedValueObject::class));
+    }
+
+    /**
+     * @test
+     */
+    public function denormalizeFailsForArrayValueObjectsWithoutNamedConstructor(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->valueObjectNormalizer->denormalize(['some' => 'array'], Fixture\InvalidArrayBasedValueObject::class);
     }
 }


### PR DESCRIPTION
Adjusts the `ValueObjectNormalizer` so that it requires a class
to implement a named constructor `fromArray(array $data)` when
denormalizing array data.

Fixes: #233