### PR TITLE
Apply default db-config on createSchema

### DIFF
--- a/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
+++ b/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
@@ -17,6 +17,7 @@ use Doctrine\DBAL\ConnectionException;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\SchemaConfig;
 use Doctrine\DBAL\Types\Type;
 use Neos\Error\Messages\Error;
 use Neos\Error\Messages\Notice;
@@ -298,7 +299,10 @@ class DoctrineEventStorage implements EventStorageInterface
      */
     private function createEventStoreSchema(): Schema
     {
-        $schema = new Schema();
+        $defaultConfig = new SchemaConfig();
+        $defaultConfig->setDefaultTableOptions($this->defaultFlowDatabaseConfiguration);
+
+        $schema = new Schema([], [], $defaultConfig);
         $table = $schema->createTable($this->eventTableName);
 
         // The monotonic sequence number

--- a/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
+++ b/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
@@ -68,11 +68,6 @@ class DoctrineEventStorage implements EventStorageInterface
     private $options;
 
     /**
-     * @var @Flow\InjectConfiguration(package="Neos.Flow", path="persistence.backendOptions")
-     */
-    protected $defaultFlowDatabaseConfiguration;
-
-    /**
      * @param array $options
      */
     public function __construct(array $options)
@@ -302,10 +297,12 @@ class DoctrineEventStorage implements EventStorageInterface
      */
     private function createEventStoreSchema(): Schema
     {
-        $defaultConfig = new SchemaConfig();
-        $defaultConfig->setDefaultTableOptions($this->defaultFlowDatabaseConfiguration);
-
-        $schema = new Schema([], [], $defaultConfig);
+        $schemaConfiguration = new SchemaConfig();
+        $connectionParameters = $this->connection->getParams();
+        if (isset($connectionParameters['defaultTableOptions'])) {
+            $schemaConfiguration->setDefaultTableOptions($connectionParameters['defaultTableOptions']);
+        }
+        $schema = new Schema([], [], $schemaConfiguration);
         $table = $schema->createTable($this->eventTableName);
 
         // The monotonic sequence number

--- a/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
+++ b/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
@@ -68,6 +68,11 @@ class DoctrineEventStorage implements EventStorageInterface
     private $options;
 
     /**
+     * @var @Flow\InjectConfiguration(package="Neos.Flow", path="persistence.backendOptions")
+     */
+    protected $defaultFlowDatabaseConfiguration;
+
+    /**
      * @param array $options
      */
     public function __construct(array $options)


### PR DESCRIPTION
Based on #237 i would suggest a solution like this. Currently the schema is generated without any configuration and this adds a SchemaConfig with the default flow config for databases.