### PR TITLE
BUGFIX: Avoid double rollBack on expected version mismatch

### DIFF
--- a/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
+++ b/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
@@ -191,7 +191,6 @@ class DoctrineEventStorage implements EventStorageInterface
         if ($expectedVersion === $actualVersion || ($expectedVersion === ExpectedVersion::STREAM_EXISTS && $actualVersion > -1)) {
             return;
         }
-        $this->connection->rollBack();
         throw new ConcurrencyException(sprintf('Expected version: %s, actual version: %s', $this->renderExpectedVersion($expectedVersion), $this->renderExpectedVersion($actualVersion)), 1477143473);
     }
 


### PR DESCRIPTION
RollBack is already done in the surrounding try/catch block of `verifyExpectedVersion()` call.