### PR TITLE
BUGFIX: Catch all throwables

### DIFF
--- a/Classes/EventListener/EventListenerInvoker.php
+++ b/Classes/EventListener/EventListenerInvoker.php
@@ -117,7 +117,7 @@ final class EventListenerInvoker
         }
         try {
             $listener->$listenerMethodName($event, $rawEvent);
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             throw new EventCouldNotBeAppliedException(sprintf('Event "%s" (%s) could not be applied to %s. Sequence number (%d) is not updated', $rawEvent->getIdentifier(), $rawEvent->getType(), get_class($listener), $rawEvent->getSequenceNumber()), 1544207001, $exception, $eventEnvelope, $listener);
         }
         if ($listener instanceof AfterInvokeInterface) {

--- a/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
+++ b/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
@@ -117,7 +117,7 @@ class DoctrineEventStorage implements EventStorageInterface
 
     /**
      * @inheritdoc
-     * @throws DBALException | ConcurrencyException | InvalidArgumentException | RuntimeException
+     * @throws DBALException | ConcurrencyException | \Throwable
      */
     public function commit(StreamName $streamName, WritableEvents $events, int $expectedVersion = ExpectedVersion::ANY): void
     {
@@ -156,7 +156,7 @@ class DoctrineEventStorage implements EventStorageInterface
             }
 
             $this->connection->commit();
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             $this->connection->rollBack();
             throw $exception;
         }
@@ -250,8 +250,7 @@ class DoctrineEventStorage implements EventStorageInterface
 
     /**
      * @inheritdoc
-     * @throws DBALException
-     * @throws \Exception
+     * @throws DBALException | \Throwable
      */
     public function setup(): Result
     {
@@ -283,7 +282,7 @@ class DoctrineEventStorage implements EventStorageInterface
                 $this->connection->exec($statement);
             }
             $this->connection->commit();
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             $this->connection->rollBack();
             throw $exception;
         }

--- a/Classes/Projection/Doctrine/DoctrineProjectionPersistenceManager.php
+++ b/Classes/Projection/Doctrine/DoctrineProjectionPersistenceManager.php
@@ -85,7 +85,7 @@ class DoctrineProjectionPersistenceManager
         }
         try {
             $this->entityManager->persist($object);
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             throw new \RuntimeException('Could not persist updated object of type "' . get_class($object) . '"', 1474531485464, $exception);
         }
         $this->garbageCollection();


### PR DESCRIPTION
Replaces `catch (\Exception)` by `catch (\Throwable)` for fail-safe roll backs

Fixes: #242