### PR TITLE
BUGFIX: Follow-up

### DIFF
--- a/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
+++ b/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
@@ -156,11 +156,12 @@ class DoctrineEventStorage implements EventStorageInterface
                 $retryWaitInterval *= 2;
                 $this->connection->rollBack();
                 continue;
-            } catch (DBALException $exception) {
+            } catch (DBALException | ConcurrencyException $exception) {
                 $this->connection->rollBack();
                 throw $exception;
             }
             $this->connection->commit();
+            break;
         }
     }
 


### PR DESCRIPTION
A follow up to #245 fixing the `DoctrineEventStorage` so that it
actually exits the retry-loop when successful (*doh).

This fix also makes sure that the transaction is rolled back when
the `verifyExpectedVersion()` call failed