### PR TITLE
Add Flow 6.x to compatible Flow versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "Lean and opinionated way to integrate Event Sourcing and CQRS pattern in your Flow framework package",
     "require": {
         "php": ">=7.0",
-        "neos/flow": "~4.0 || ~5.0 || dev-master"
+        "neos/flow": "~4.0 || ~5.0 || ~6.0 || dev-master"
     },
     "suggest": {
         "php-uuid": "For fast generation of UUIDs used in the persistence."


### PR DESCRIPTION
Add the possibility to use the 1.0 version of Neos.EventSourcing with Flow 6.x. 