### PR TITLE
!!! BUGFIX: Release "highest applied sequence number" during catchup

### DIFF
--- a/Classes/EventListener/EventListenerInvoker.php
+++ b/Classes/EventListener/EventListenerInvoker.php
@@ -12,7 +12,7 @@ namespace Neos\EventSourcing\EventListener;
  * source code.
  */
 
-use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\DBAL\Connection;
 use Neos\EventSourcing\EventListener\AppliedEventsStorage\AppliedEventsStorageInterface;
 use Neos\EventSourcing\EventListener\AppliedEventsStorage\DoctrineAppliedEventsStorage;
 use Neos\EventSourcing\EventListener\Exception\EventCouldNotBeAppliedException;
@@ -20,7 +20,6 @@ use Neos\EventSourcing\EventStore\EventEnvelope;
 use Neos\EventSourcing\EventStore\EventStore;
 use Neos\EventSourcing\EventStore\StreamAwareEventListenerInterface;
 use Neos\EventSourcing\EventStore\StreamName;
-use Neos\Flow\Annotations as Flow;
 
 final class EventListenerInvoker
 {
@@ -31,111 +30,153 @@ final class EventListenerInvoker
     private $eventStore;
 
     /**
-     * @Flow\Inject
-     * @var EntityManagerInterface
+     * @var EventListenerInterface
      */
-    protected $entityManager;
+    private $eventListener;
 
-    public function __construct(EventStore $eventStore)
+    /**
+     * DBAL connection for the DoctrineAppliedEventsStorage (@see getAppliedEventsStorageForListener())
+     *
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * @var \Closure[]
+     */
+    private $progressCallbacks = [];
+
+    /**
+     * How many events should be applied until the whole transaction is committed
+     * and the highest applied sequence number is persisted.
+     * By default the transaction is committed for every event (batch size = 1)
+     *
+     * @var int
+     */
+    private $transactionBatchSize = 1;
+
+    public function __construct(EventStore $eventStore, EventListenerInterface $eventListener, Connection $connection)
     {
         $this->eventStore = $eventStore;
+        $this->eventListener = $eventListener;
+        $this->connection = $connection;
     }
 
     /**
-     * @param EventListenerInterface $listener
-     * @param \Closure $progressCallback
+     * Register a callback that is invoked for every event that is applied during replay/catchup
+     *
+     * @param \Closure $callback
+     */
+    public function onProgress(\Closure $callback): void
+    {
+        $this->progressCallbacks[] = $callback;
+    }
+
+    /**
+     * Returns an instance with the transaction batch size.
+     * This allows for faster replays/catchups at the cost of an "at least once delivery" if an error occurs.
+     *
+     * Usage:
+     * $eventListenerInvoker = (new EventListenerInvoker($eventStore, $listener, $connection))->withTransactionBatchSize(100)->catchUp($listener);
+     *
+     * @param int $batchSize
+     * @return $this
+     */
+    public function withTransactionBatchSize(int $batchSize): self
+    {
+        if ($batchSize < 1) {
+            throw new \InvalidArgumentException('The batch size must not be smaller than 1', 1584276378);
+        }
+        $instance = new static($this->eventStore, $this->eventListener, $this->connection);
+        $instance->progressCallbacks = $this->progressCallbacks;
+        $instance->transactionBatchSize = $batchSize;
+        return $instance;
+    }
+
+    /**
      * @throws EventCouldNotBeAppliedException
      */
-    public function replay(EventListenerInterface $listener, \Closure $progressCallback = null): void
+    public function replay(): void
     {
-        $appliedEventsStorage = $this->getAppliedEventsStorageForListener($listener);
+        $appliedEventsStorage = $this->getAppliedEventsStorage();
         $highestAppliedSequenceNumber = -1;
         $appliedEventsStorage->saveHighestAppliedSequenceNumber($highestAppliedSequenceNumber);
-        $highestAppliedSequenceNumber = $appliedEventsStorage->reserveHighestAppliedEventSequenceNumber();
-
-        $streamName = $listener instanceof StreamAwareEventListenerInterface ? $listener::listensToStream() : StreamName::all();
-        $eventStream = $this->eventStore->load($streamName);
-        foreach ($eventStream as $eventEnvelope) {
-            try {
-                $this->applyEvent($listener, $eventEnvelope);
-                $highestAppliedSequenceNumber = $eventEnvelope->getRawEvent()->getSequenceNumber();
-            } catch (EventCouldNotBeAppliedException $exception) {
-                $appliedEventsStorage->saveHighestAppliedSequenceNumber($highestAppliedSequenceNumber);
-                $appliedEventsStorage->releaseHighestAppliedSequenceNumber();
-                throw $exception;
-            }
-            if ($progressCallback !== null) {
-                $progressCallback($eventEnvelope);
-            }
-        }
-        $appliedEventsStorage->saveHighestAppliedSequenceNumber($highestAppliedSequenceNumber);
-        $appliedEventsStorage->releaseHighestAppliedSequenceNumber();
+        $this->catchUp();
     }
 
     /**
-     * @param EventListenerInterface $listener
-     * @param \Closure $progressCallback
      * @throws EventCouldNotBeAppliedException
      */
-    public function catchUp(EventListenerInterface $listener, \Closure $progressCallback = null): void
+    public function catchUp(): void
     {
-        $appliedEventsStorage = $this->getAppliedEventsStorageForListener($listener);
+        $appliedEventsStorage = $this->getAppliedEventsStorage();
         $highestAppliedSequenceNumber = $appliedEventsStorage->reserveHighestAppliedEventSequenceNumber();
-        $streamName = $listener instanceof StreamAwareEventListenerInterface ? $listener::listensToStream() : StreamName::all();
+        $streamName = $this->eventListener instanceof StreamAwareEventListenerInterface ? $this->eventListener::listensToStream() : StreamName::all();
         $eventStream = $this->eventStore->load($streamName, $highestAppliedSequenceNumber + 1);
+        $appliedEventsCounter = 0;
         foreach ($eventStream as $eventEnvelope) {
+            $sequenceNumber = $eventEnvelope->getRawEvent()->getSequenceNumber();
+            if ($sequenceNumber <= $highestAppliedSequenceNumber) {
+                continue;
+            }
             try {
-                $this->applyEvent($listener, $eventEnvelope);
+                $this->applyEvent($eventEnvelope);
             } catch (EventCouldNotBeAppliedException $exception) {
                 $appliedEventsStorage->releaseHighestAppliedSequenceNumber();
                 throw $exception;
             }
+            $appliedEventsCounter ++;
             $appliedEventsStorage->saveHighestAppliedSequenceNumber($eventEnvelope->getRawEvent()->getSequenceNumber());
-            if ($progressCallback !== null) {
-                $progressCallback($eventEnvelope);
+            if ($this->transactionBatchSize === 1 || $appliedEventsCounter % $this->transactionBatchSize === 0) {
+                $appliedEventsStorage->releaseHighestAppliedSequenceNumber();
+                $highestAppliedSequenceNumber = $appliedEventsStorage->reserveHighestAppliedEventSequenceNumber();
+            } else {
+                $highestAppliedSequenceNumber = $sequenceNumber;
+            }
+            foreach ($this->progressCallbacks as $callback) {
+                $callback($eventEnvelope);
             }
         }
         $appliedEventsStorage->releaseHighestAppliedSequenceNumber();
     }
 
     /**
-     * @param EventListenerInterface $listener
      * @param EventEnvelope $eventEnvelope
      * @throws EventCouldNotBeAppliedException
      */
-    private function applyEvent(EventListenerInterface $listener, EventEnvelope $eventEnvelope): void
+    private function applyEvent(EventEnvelope $eventEnvelope): void
     {
         $event = $eventEnvelope->getDomainEvent();
         $rawEvent = $eventEnvelope->getRawEvent();
         try {
             $listenerMethodName = 'when' . (new \ReflectionClass($event))->getShortName();
         } catch (\ReflectionException $exception) {
-            throw new \RuntimeException(sprintf('Could not extract listener method name for listener %s and event %s', get_class($listener), get_class($event)), 1541003718, $exception);
+            throw new \RuntimeException(sprintf('Could not extract listener method name for listener %s and event %s', get_class($this->eventListener), get_class($event)), 1541003718, $exception);
         }
-        if (!method_exists($listener, $listenerMethodName)) {
+        if (!method_exists($this->eventListener, $listenerMethodName)) {
             return;
         }
-        if ($listener instanceof BeforeInvokeInterface) {
-            $listener->beforeInvoke($eventEnvelope);
+        if ($this->eventListener instanceof BeforeInvokeInterface) {
+            $this->eventListener->beforeInvoke($eventEnvelope);
         }
         try {
-            $listener->$listenerMethodName($event, $rawEvent);
+            $this->eventListener->$listenerMethodName($event, $rawEvent);
         } catch (\Throwable $exception) {
-            throw new EventCouldNotBeAppliedException(sprintf('Event "%s" (%s) could not be applied to %s. Sequence number (%d) is not updated', $rawEvent->getIdentifier(), $rawEvent->getType(), get_class($listener), $rawEvent->getSequenceNumber()), 1544207001, $exception, $eventEnvelope, $listener);
+            throw new EventCouldNotBeAppliedException(sprintf('Event "%s" (%s) could not be applied to %s. Sequence number (%d) is not updated', $rawEvent->getIdentifier(), $rawEvent->getType(), get_class($this->eventListener), $rawEvent->getSequenceNumber()), 1544207001, $exception, $eventEnvelope, $this->eventListener);
         }
-        if ($listener instanceof AfterInvokeInterface) {
-            $listener->afterInvoke($eventEnvelope);
+        if ($this->eventListener instanceof AfterInvokeInterface) {
+            $this->eventListener->afterInvoke($eventEnvelope);
         }
     }
 
-    private function getAppliedEventsStorageForListener(EventListenerInterface $listener): AppliedEventsStorageInterface
+    private function getAppliedEventsStorage(): AppliedEventsStorageInterface
     {
-        if ($listener instanceof ProvidesAppliedEventsStorageInterface) {
-            $appliedEventsStorage = $listener->getAppliedEventsStorage();
-        } elseif ($listener instanceof AppliedEventsStorageInterface) {
-            $appliedEventsStorage = $listener;
+        if ($this->eventListener instanceof ProvidesAppliedEventsStorageInterface) {
+            $appliedEventsStorage = $this->eventListener->getAppliedEventsStorage();
+        } elseif ($this->eventListener instanceof AppliedEventsStorageInterface) {
+            $appliedEventsStorage = $this->eventListener;
         } else {
-            $appliedEventsStorage = new DoctrineAppliedEventsStorage($this->entityManager->getConnection(), \get_class($listener));
+            $appliedEventsStorage = new DoctrineAppliedEventsStorage($this->connection, \get_class($this->eventListener));
         }
         return $appliedEventsStorage;
     }

--- a/Classes/EventPublisher/JobQueue/CatchUpEventListenerJob.php
+++ b/Classes/EventPublisher/JobQueue/CatchUpEventListenerJob.php
@@ -12,6 +12,7 @@ namespace Neos\EventSourcing\EventPublisher\JobQueue;
  * source code.
  */
 
+use Doctrine\ORM\EntityManagerInterface;
 use Flowpack\JobQueue\Common\Job\JobInterface;
 use Flowpack\JobQueue\Common\Queue\Message;
 use Flowpack\JobQueue\Common\Queue\QueueInterface;
@@ -40,6 +41,12 @@ final class CatchUpEventListenerJob implements JobInterface
      * @var ObjectManagerInterface
      */
     protected $objectManager;
+
+    /**
+     * @Flow\Inject
+     * @var EntityManagerInterface
+     */
+    protected $entityManager;
 
     public function __construct(string $listenerClassName, string $eventStoreIdentifier)
     {
@@ -72,8 +79,8 @@ final class CatchUpEventListenerJob implements JobInterface
         $eventStoreFactory = $this->objectManager->get(EventStoreFactory::class);
         $eventStore = $eventStoreFactory->create($this->eventStoreIdentifier);
 
-        $eventListenerInvoker = new EventListenerInvoker($eventStore);
-        $eventListenerInvoker->catchUp($listener);
+        $eventListenerInvoker = new EventListenerInvoker($eventStore, $listener, $this->entityManager->getConnection());
+        $eventListenerInvoker->catchUp();
         return true;
     }
 

--- a/Classes/Projection/ProjectionManager.php
+++ b/Classes/Projection/ProjectionManager.php
@@ -12,6 +12,7 @@ namespace Neos\EventSourcing\Projection;
  * source code.
  */
 
+use Doctrine\ORM\EntityManagerInterface;
 use Neos\EventSourcing\EventListener\EventListenerInvoker;
 use Neos\EventSourcing\EventListener\Exception\EventCouldNotBeAppliedException;
 use Neos\EventSourcing\EventListener\Mapping\DefaultEventToListenerMappingProvider;
@@ -111,8 +112,12 @@ class ProjectionManager
         $projector = $this->objectManager->get($projection->getProjectorClassName());
         $projector->reset();
 
-        $eventListenerInvoker = new EventListenerInvoker($eventStore);
-        $eventListenerInvoker->replay($projector, $progressCallback);
+        $connection = $this->objectManager->get(EntityManagerInterface::class)->getConnection();
+        $eventListenerInvoker = new EventListenerInvoker($eventStore, $projector, $connection);
+        if ($progressCallback !== null) {
+            $eventListenerInvoker->onProgress($progressCallback);
+        }
+        $eventListenerInvoker->replay();
     }
 
     /**

--- a/Tests/Unit/EventListener/EventListenerInvokerTest.php
+++ b/Tests/Unit/EventListener/EventListenerInvokerTest.php
@@ -1,0 +1,127 @@
+<?php
+declare(strict_types=1);
+namespace Neos\EventSourcing\Tests\Unit\EventListener;
+
+use DG\BypassFinals;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Neos\EventSourcing\EventListener\AppliedEventsStorage\AppliedEventsStorageInterface;
+use Neos\EventSourcing\EventListener\EventListenerInterface;
+use Neos\EventSourcing\EventListener\EventListenerInvoker;
+use Neos\EventSourcing\EventListener\ProvidesAppliedEventsStorageInterface;
+use Neos\EventSourcing\EventStore\EventStore;
+use Neos\EventSourcing\EventStore\EventStream;
+use Neos\EventSourcing\EventStore\StreamAwareEventListenerInterface;
+use Neos\EventSourcing\EventStore\StreamName;
+use Neos\Flow\Tests\UnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class EventListenerInvokerTest extends UnitTestCase
+{
+    /**
+     * @var EventListenerInvoker
+     */
+    private $eventListenerInvoker;
+
+    /**
+     * @var EventStore|MockObject
+     */
+    private $mockEventStore;
+
+    /**
+     * @var Connection|MockObject
+     */
+    private $mockConnection;
+
+    /**
+     * @var EventStream|MockObject
+     */
+    private $mockEventStream;
+
+    /**
+     * @var EventListenerInterface|ProvidesAppliedEventsStorageInterface|MockObject
+     */
+    private $mockEventListener;
+
+    /**
+     * @var AppliedEventsStorageInterface|MockObject
+     */
+    private $mockAppliedEventsStorage;
+
+    /** @noinspection ClassMockingCorrectnessInspection */
+    public function setUp(): void
+    {
+        BypassFinals::enable();
+        $this->mockEventStore = $this->getMockBuilder(EventStore::class)->disableOriginalConstructor()->getMock();
+
+        $this->mockConnection = $this->getMockBuilder(Connection::class)->disableOriginalConstructor()->getMock();
+        $this->mockConnection->method('getTransactionNestingLevel')->willReturn(0);
+        $mockPlatform = $this->getMockBuilder(AbstractPlatform::class)->getMock();
+        $this->mockConnection->method('getDatabasePlatform')->willReturn($mockPlatform);
+
+        $this->mockEventListener = $this->getMockBuilder(EventListenerInterface::class)->getMock();
+
+        $this->eventListenerInvoker = new EventListenerInvoker($this->mockEventStore, $this->mockEventListener, $this->mockConnection);
+
+        $this->mockAppliedEventsStorage = $this->getMockBuilder(AppliedEventsStorageInterface::class)->getMock();
+
+        $this->mockEventStream = $this->getMockBuilder(EventStream::class)->disableOriginalConstructor()->getMock();
+    }
+
+    /**
+     * @test
+     */
+    public function catchUpPassesRespectsReservedSequenceNumber(): void
+    {
+        $this->mockConnection->method('fetchColumn')->willReturn(123);
+        $this->mockEventStore->expects($this->once())->method('load')->with(StreamName::all(), 124)->willReturn($this->mockEventStream);
+        $this->eventListenerInvoker->catchUp();
+    }
+
+
+    /**
+     * @test
+     */
+    public function catchUpPassesRespectsProvidesAppliedEventsStorageInterface(): void
+    {
+        /** @var EventListenerInterface|MockObject $mockEventListener */
+        $mockEventListener = $this->getMockBuilder([EventListenerInterface::class, ProvidesAppliedEventsStorageInterface::class])->getMock();
+        $mockEventListener->method('getAppliedEventsStorage')->willReturn($this->mockAppliedEventsStorage);
+
+        $this->eventListenerInvoker = new EventListenerInvoker($this->mockEventStore, $mockEventListener, $this->mockConnection);
+
+        $this->mockAppliedEventsStorage->expects($this->atLeastOnce())->method('reserveHighestAppliedEventSequenceNumber')->willReturn(123);
+        $this->mockEventStore->expects($this->once())->method('load')->with(StreamName::all(), 124)->willReturn($this->mockEventStream);
+        $this->eventListenerInvoker->catchUp();
+    }
+
+    /**
+     * @test
+     */
+    public function catchUpPassesRespectsStreamAwareEventListenerInterface(): void
+    {
+        $streamName = StreamName::fromString('some-stream');
+        $mockEventListener = $this->buildMockEventListener($streamName);
+        $this->eventListenerInvoker = new EventListenerInvoker($this->mockEventStore, $mockEventListener, $this->mockConnection);
+        $this->mockEventStore->expects($this->once())->method('load')->with($streamName, 1)->willReturn($this->mockEventStream);
+        $this->eventListenerInvoker->catchUp();
+    }
+
+    private function buildMockEventListener(StreamName $streamName = null): EventListenerInterface
+    {
+        $listenerClassName = 'Mock_EventListener_' . md5(uniqid('', true));
+        $listenerCode = 'class ' . $listenerClassName . ' implements ' . EventListenerInterface::class;
+        if ($streamName !== null) {
+            $listenerCode .= ', ' . StreamAwareEventListenerInterface::class;
+        }
+        $listenerCode .= ' {';
+        if ($streamName !== null) {
+            $listenerCode .= 'public static function listensToStream(): ' . StreamName::class . ' { return ' . StreamName::class . '::fromString(\'' . (string)$streamName . '\'); }';
+        }
+        $listenerCode .= '}';
+
+        eval($listenerCode);
+        return new $listenerClassName();
+    }
+
+}

--- a/Tests/Unit/EventListener/Fixture/AppliedEventsStorageEventListener.php
+++ b/Tests/Unit/EventListener/Fixture/AppliedEventsStorageEventListener.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\EventSourcing\Tests\Unit\EventListener\Fixture;
+
+use Neos\EventSourcing\EventListener\AppliedEventsStorage\AppliedEventsStorageInterface;
+use Neos\EventSourcing\EventListener\EventListenerInterface;
+use Neos\EventSourcing\EventListener\ProvidesAppliedEventsStorageInterface;
+
+class AppliedEventsStorageEventListener implements EventListenerInterface, ProvidesAppliedEventsStorageInterface
+{
+
+    /**
+     * @var AppliedEventsStorageInterface
+     */
+    private $appliedEventsStorage;
+
+    public function __construct(AppliedEventsStorageInterface $appliedEventsStorage)
+    {
+        $this->appliedEventsStorage = $appliedEventsStorage;
+    }
+
+    public function getAppliedEventsStorage(): AppliedEventsStorageInterface
+    {
+        return $this->appliedEventsStorage;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,10 @@
         "symfony/serializer": "^4.2",
         "symfony/property-access": "^3.4"
     },
+    "require-dev": {
+        "roave/security-advisories": "dev-master",
+        "dg/bypass-finals": "^1.1"
+    },
     "suggest": {
         "php-uuid": "For fast generation of UUIDs used in the persistence."
     },


### PR DESCRIPTION
Previously the whole `EventListenerInvoker::catchup()` call triggered a
single blocking transaction that was only committed when the corresponding
event listener was up to date with the event store.
Especially for replays and initial catchups this posed a problem because
of the ever growing transaction.

With this change the "Highest Applied Sequence Number" is released after
each applied event.
This has the nice side effect that multiple workers can share the load:
While process 1 commits the transaction, process 2 can already start processing
the next event.

For batch-processing the batch size can be increased in order to improve performance:

    $eventListenerInvoker = (new EventListenerInvoker($eventStore, $listener, $connection))
       ->withTransactionBatchSize(500)
       ->catchup()

This is a breaking change because the signature of the `EventListenerInvoker` has
changed slightly:

Previously:

    $eventListenerInvoker = new EventListenerInvoker($eventStore);
    $eventListenerInvoker->catchup($listener, $progressCallback);

Now:

    $eventListenerInvoker = new EventListenerInvoker($eventStore, $listener, $connection);
    $eventListenerInvoker->onProgress($eventListenerInvoker);
    $eventListenerInvoker->catchup();

Fixes: #261