### PR TITLE
BUGFIX: Relax DefaultEventToListenerMappingProvider checks

### DIFF
--- a/Classes/EventListener/Mapping/DefaultEventToListenerMappingProvider.php
+++ b/Classes/EventListener/Mapping/DefaultEventToListenerMappingProvider.php
@@ -34,7 +34,7 @@ class DefaultEventToListenerMappingProvider
     /**
      * @var EventToListenerMappings[] indexed by the corresponding EventStore identifier
      */
-    private $mappings;
+    private $mappings = [];
 
     /**
      * This class is usually not instantiated manually but injected like other singletons
@@ -108,7 +108,7 @@ class DefaultEventToListenerMappingProvider
                 return $presetOptions !== false;
             });
             if ($presetsForThisStore === []) {
-                throw new InvalidConfigurationException(sprintf('No Event Listeners are configured for Event Store "%s". Please register at least one listener via Neos.EventSourcing.EventStore.stores.*.listeners or disable this Event Store', $eventStoreIdentifier), 1577534654);
+                $mappings[$eventStoreIdentifier] = [];
             }
             foreach ($presetsForThisStore as $pattern => $presetOptions) {
                 $presetId = $eventStoreIdentifier . '.' . $pattern;

--- a/Resources/Private/Schema/Settings/Neos.EventSourcing.schema.yaml
+++ b/Resources/Private/Schema/Settings/Neos.EventSourcing.schema.yaml
@@ -19,7 +19,7 @@ properties:
                 'storageOptions': {type: dictionary}
                 'eventPublisherFactory': {type: string, format: class-name}
                 'listeners':
-                  required: true
+                  required: false
                   type: dictionary
                   additionalProperties:
                     type: [boolean, dictionary]

--- a/Tests/Unit/EventListener/Mapping/DefaultEventToListenerMappingProviderTest.php
+++ b/Tests/Unit/EventListener/Mapping/DefaultEventToListenerMappingProviderTest.php
@@ -201,10 +201,6 @@ class DefaultEventToListenerMappingProviderTest extends UnitTestCase
                 'eventStoresConfiguration' => ['es1' => ['listeners' => ['Mock_EventListener_1.*' => []]], 'es2' => ['listeners' => ['Mock_EventListener_2.*' => []]]],
                 'expectedException' => 1577532358,
             ],
-            'missing es listeners' => [
-                'eventStoresConfiguration' => ['es1' => ['listeners' => ['.*' => []]], 'es2' => ['listeners' => ['some-pattern' => false]]],
-                'expectedException' => 1577534654,
-            ],
             'overlapping listeners' => [
                 'eventStoresConfiguration' => ['es1' => ['listeners' => ['.*' => []]], 'es2' => ['listeners' => ['Mock_EventListener_2.*' => []]]],
                 'expectedException' => 1577532711,
@@ -315,7 +311,7 @@ class DefaultEventToListenerMappingProviderTest extends UnitTestCase
     /**
      * @test
      */
-    public function constructorCreatesMappingsForMultipleStoresWithMultipleoptionss(): void
+    public function constructorCreatesMappingsForMultipleStoresWithMultipleOptions(): void
     {
         $this->eventStoresConfiguration = ['default' => ['listeners' => ['Mock_EventListener_1.*' => ['options' => '1'], 'Mock_EventListener_3.*' => ['options' => '2']]], 'es2' => ['listeners' => ['Mock_EventListener_2.*' => ['options' => '3']]]];
 
@@ -336,6 +332,32 @@ class DefaultEventToListenerMappingProviderTest extends UnitTestCase
             'es2' => [
                 ['eventClassName' => DummyEvent2::class, 'listenerClassName' => $listenerClassName2, 'options' => ['options' => '3']],
                 ['eventClassName' => DummyEvent3::class, 'listenerClassName' => $listenerClassName2, 'options' => ['options' => '3']],
+            ]
+        ];
+        $this->assetMappings($expectedMappings, $defaultMappingsProvider);
+    }
+
+    /**
+     * @test
+     */
+    public function constructorCreatesEmptyMappingsForStoresWithoutListenersConfiguration(): void
+    {
+        $this->eventStoresConfiguration = ['es1' => ['listeners' => ['.*' => []]], 'es2' => ['listeners' => ['some-pattern' => false]]];
+
+        $listenerClassName1 = $this->buildMockEventListenerForEvents([DummyEvent1::class, DummyEvent2::class], 'Mock_EventListener_1');
+        $listenerClassName2 = $this->buildMockEventListenerForEvents([DummyEvent2::class, DummyEvent3::class], 'Mock_EventListener_2');
+        $this->mockListenerClassNames = [$listenerClassName1, $listenerClassName2];
+
+        /** @noinspection PhpUnhandledExceptionInspection */
+        $defaultMappingsProvider = new DefaultEventToListenerMappingProvider($this->mockObjectManager);
+        $expectedMappings = [
+            'es1' => [
+                ['eventClassName' => DummyEvent1::class, 'listenerClassName' => $listenerClassName1, 'options' => []],
+                ['eventClassName' => DummyEvent2::class, 'listenerClassName' => $listenerClassName1, 'options' => []],
+                ['eventClassName' => DummyEvent2::class, 'listenerClassName' => $listenerClassName2, 'options' => []],
+                ['eventClassName' => DummyEvent3::class, 'listenerClassName' => $listenerClassName2, 'options' => []],
+            ],
+            'es2' => [
             ]
         ];
         $this->assetMappings($expectedMappings, $defaultMappingsProvider);


### PR DESCRIPTION
With #256 the `DefaultEventToListenerMappingProvider` was introduced
with a very defensive behavior that prevents event store configurations
without matching Listeners.

This was taking it a little far and creates a hen-egg situation for the
initial setup because it requires an `EventListenerInterface` instance
to exist before a store can be configured.

With this change it's allowed to leave out the `listeners` configuration:

```yaml
Neos:
  EventSourcing:
    EventStore:
      stores:
        'event-store':
          storage: 'Neos\EventSourcing\EventStore\Storage\Doctrine\DoctrineEventStorage'
```

If one is specified it is still validated of course, so the follwing example will lead
to an exception if no EventListener exists yet:

```yaml
Neos:
  EventSourcing:
    EventStore:
      stores:
        'event-store':
          storage: 'Neos\EventSourcing\EventStore\Storage\Doctrine\DoctrineEventStorage'
          listeners:
            '.*': true
```