### PR TITLE
BUGFIX: Fix recordedAt column type for DoctrineEventStorage

### DIFF
--- a/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
+++ b/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
@@ -351,7 +351,7 @@ class DoctrineEventStorage implements EventStorageInterface
         // An optional causation id, usually a UUID
         $table->addColumn('causationidentifier', Types::STRING, ['length' => 255, 'notnull' => false]);
         // Timestamp of the the event publishing
-        $table->addColumn('recordedat', Types::DATE_IMMUTABLE);
+        $table->addColumn('recordedat', Types::DATETIME_IMMUTABLE);
 
         $table->setPrimaryKey(['sequencenumber']);
         $table->addUniqueIndex(['id'], 'id_uniq');


### PR DESCRIPTION
Fixes a regression introduced with 4ec28d36644acab4b21fc1db50903e6058c8b669 that
led to the `recordedAt` column of published events to miss the time component.

To apply the fix, run

    ./flow eventstore:setupall