### PR TITLE
FEATURE: Replay / catch up until sequence number

### DIFF
--- a/Classes/EventStore/Storage/InMemory/InMemoryStreamIterator.php
+++ b/Classes/EventStore/Storage/InMemory/InMemoryStreamIterator.php
@@ -1,0 +1,111 @@
+<?php
+declare(strict_types=1);
+namespace Neos\EventSourcing\EventStore\Storage\InMemory;
+
+/*
+ * This file is part of the Neos.EventSourcing package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use ArrayIterator;
+use Neos\EventSourcing\EventStore\EventStreamIteratorInterface;
+use Neos\EventSourcing\EventStore\RawEvent;
+use Neos\EventSourcing\EventStore\StreamName;
+
+/**
+ * Stream Iterator for an in-memory based EventStore – intended for testing
+ */
+final class InMemoryStreamIterator implements EventStreamIteratorInterface
+{
+    /**
+     * @var int
+     */
+    private $currentOffset = 0;
+
+    /**
+     * @var ArrayIterator
+     */
+    private $innerIterator;
+
+    /**
+     * @var array
+     */
+    private $eventRecords = [];
+
+    /**
+     * @param array $eventRecords
+     */
+    public function setEventRecords(array $eventRecords): void
+    {
+        $this->eventRecords = $eventRecords;
+        $this->innerIterator = new ArrayIterator($this->eventRecords);
+    }
+
+    /**
+     * @return RawEvent
+     * @throws \JsonException
+     */
+    public function current(): RawEvent
+    {
+        $currentEventData = $this->innerIterator->current();
+        $payload = json_decode($currentEventData['payload'], true, 512, JSON_THROW_ON_ERROR);
+        $metadata = json_decode($currentEventData['metadata'], true, 512, JSON_THROW_ON_ERROR);
+        try {
+            $recordedAt = new \DateTimeImmutable($currentEventData['recordedat']);
+        } catch (\Exception $exception) {
+            throw new \RuntimeException(sprintf('Could not parse recordedat timestamp "%s" as date.', $currentEventData['recordedat']), 1597843669, $exception);
+        }
+        return new RawEvent(
+            (int)$currentEventData['sequencenumber'],
+            $currentEventData['type'],
+            $payload,
+            $metadata,
+            StreamName::fromString($currentEventData['stream']),
+            (int)$currentEventData['version'],
+            $currentEventData['id'],
+            $recordedAt
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function next(): void
+    {
+        $this->currentOffset = $this->innerIterator->current()['sequencenumber'];
+        $this->innerIterator->next();
+    }
+
+    /**
+     * @return bool|int
+     */
+    public function key()
+    {
+        return $this->innerIterator->valid() ? $this->innerIterator->current()['sequencenumber'] : null;
+    }
+
+    /**
+     * @return bool
+     */
+    public function valid(): bool
+    {
+        return $this->innerIterator->valid();
+    }
+
+    /**
+     * @return void
+     */
+    public function rewind(): void
+    {
+        if ($this->currentOffset === 0) {
+            return;
+        }
+        $this->innerIterator->rewind();
+        $this->currentOffset = 0;
+    }
+}

--- a/Tests/Unit/EventStore/Storage/InMemory/InMemoryStreamIteratorTest.php
+++ b/Tests/Unit/EventStore/Storage/InMemory/InMemoryStreamIteratorTest.php
@@ -1,0 +1,107 @@
+<?php
+declare(strict_types=1);
+namespace Neos\EventSourcing\Tests\Unit\EventStore\Storage\InMemory;
+
+use Neos\EventSourcing\EventStore\Storage\InMemory\InMemoryStreamIterator;
+use Neos\Flow\Tests\UnitTestCase;
+use Ramsey\Uuid\Uuid;
+
+class InMemoryStreamIteratorTest extends UnitTestCase
+{
+    /**
+     * @var InMemoryStreamIterator
+     */
+    private $iterator;
+
+    /**
+     * @throws
+     */
+    public function setUp()
+    {
+        $this->iterator = new InMemoryStreamIterator();
+        $this->iterator->setEventRecords([
+            [
+                'sequencenumber' => 1,
+                'type' => 'FooEventType',
+                'payload' => json_encode(['foo' => 'bar'], JSON_THROW_ON_ERROR, 512),
+                'metadata' => json_encode([], JSON_THROW_ON_ERROR, 512),
+                'recordedat' => '2020-08-17',
+                'stream' => 'FooStreamName',
+                'version' => 1,
+                'id' => Uuid::uuid4()->toString()
+            ],
+            [
+                'sequencenumber' => 2,
+                'type' => 'FooEventType',
+                'payload' => json_encode(['foo' => 'bar'], JSON_THROW_ON_ERROR, 512),
+                'metadata' => json_encode([], JSON_THROW_ON_ERROR, 512),
+                'recordedat' => '2020-08-17',
+                'stream' => 'FooStreamName',
+                'version' => 2,
+                'id' => Uuid::uuid4()->toString()
+            ]
+        ]);
+    }
+
+    /**
+     * @test
+     * @throws
+     */
+    public function setEventRecordsRejectsInvalidDate(): void
+    {
+        $iterator = new InMemoryStreamIterator();
+        $iterator->setEventRecords([
+            [
+                'sequencenumber' => 1,
+                'type' => 'FooEventType',
+                'payload' => json_encode(['foo' => 'bar'], JSON_THROW_ON_ERROR, 512),
+                'metadata' => json_encode([], JSON_THROW_ON_ERROR, 512),
+                'recordedat' => 'invalid-date',
+                'stream' => 'FooStreamName',
+                'version' => 1,
+                'id' => Uuid::uuid4()->toString()
+            ]
+        ]);
+
+        $this->expectExceptionCode(1597843669);
+        $iterator->current();
+    }
+
+    /**
+     * @test
+     * @throws
+     */
+    public function canSetEventRecordsAndGetRawEvents(): void
+    {
+        $rawEvent = $this->iterator->current();
+        $this->assertSame($rawEvent->getSequenceNumber(), 1);
+        $this->assertSame($rawEvent->getType(), 'FooEventType');
+        $this->assertSame($rawEvent->getRecordedAt()->format('Y-m-d'), '2020-08-17');
+        $this->assertSame((string)$rawEvent->getStreamName(), 'FooStreamName');
+    }
+
+    /**
+     * @test
+     * @throws
+     */
+    public function providesIteratorFunctions(): void
+    {
+        $this->assertSame($this->iterator->key(), 1);
+
+        $this->iterator->next();
+        $this->assertSame($this->iterator->key(), 2);
+        $this->assertSame($this->iterator->current()->getSequenceNumber(), 2);
+
+        $this->assertTrue($this->iterator->valid());
+        $this->iterator->next();
+        $this->assertFalse($this->iterator->valid());
+
+        $this->iterator->rewind();
+        $this->assertTrue($this->iterator->valid());
+        $this->assertSame($this->iterator->key(), 1);
+
+        $this->iterator->rewind();
+        $this->assertTrue($this->iterator->valid());
+        $this->assertSame($this->iterator->key(), 1);
+    }
+}


### PR DESCRIPTION
This change introduces a feature which allows for applying events
(catchup / replay) up to a specified event sequence number. Besides
supporting this in the `EventListenerInvoker`, the feature is also
provided by the `projection:replay` and `projection:replayall`
commands which introduce a new flag for this purpose.

Resolves #268