### PR TITLE
FEATURE: Introduce projection:catchup command

### DIFF
--- a/Classes/Projection/ProjectionManager.php
+++ b/Classes/Projection/ProjectionManager.php
@@ -63,7 +63,7 @@ class ProjectionManager
      * Register event listeners based on annotations
      * @throws ClassLoadingForReflectionFailedException
      */
-    protected function initializeObject(): void
+    public function initializeObject(): void
     {
         $this->projections = static::detectProjectors($this->objectManager);
     }

--- a/Classes/Projection/ProjectionManager.php
+++ b/Classes/Projection/ProjectionManager.php
@@ -129,10 +129,43 @@ class ProjectionManager
     }
 
     /**
+     * Catch up on events for the specified projection
+     *
+     * @param string $projectionIdentifier unambiguous identifier of the projection to catch up for
+     * @param Closure|null $progressCallback If set, this callback is invoked for every applied event during catch-up with the arguments $sequenceNumber and $eventStreamVersion
+     * @throws EventCouldNotBeAppliedException
+     */
+    public function catchUp(string $projectionIdentifier, Closure $progressCallback = null): void
+    {
+        $eventListenerInvoker = $this->createEventListenerInvokerForProjection($projectionIdentifier);
+        if ($progressCallback !== null) {
+            $eventListenerInvoker->onProgress($progressCallback);
+        }
+        $eventListenerInvoker->catchUp();
+    }
+
+    /**
+     * Catch up on events for the specified projection up to the specified event
+     *
+     * @param string $projectionIdentifier unambiguous identifier of the projection to catch up for
+     * @param int $maximumSequenceNumber The sequence number of the event until which events should be applied. The specified event will be included in the replay.
+      * @param Closure|null $progressCallback If set, this callback is invoked for every applied event during catch-up with the arguments $sequenceNumber and $eventStreamVersion
+     * @throws EventCouldNotBeAppliedException
+     */
+    public function catchUpUntilSequenceNumber(string $projectionIdentifier, int $maximumSequenceNumber, Closure $progressCallback = null): void
+    {
+        $eventListenerInvoker = $this->createEventListenerInvokerForProjection($projectionIdentifier)->withMaximumSequenceNumber($maximumSequenceNumber);
+        if ($progressCallback !== null) {
+            $eventListenerInvoker->onProgress($progressCallback);
+        }
+        $eventListenerInvoker->catchUp();
+    }
+
+    /**
      * @param string $projectionIdentifier
      * @return EventListenerInvoker
      */
-    private function createEventListenerInvokerForProjection(string $projectionIdentifier): EventListenerInvoker
+    protected function createEventListenerInvokerForProjection(string $projectionIdentifier): EventListenerInvoker
     {
         $projection = $this->getProjection($projectionIdentifier);
 

--- a/Tests/Unit/Projection/ProjectionManagerTest.php
+++ b/Tests/Unit/Projection/ProjectionManagerTest.php
@@ -1,0 +1,89 @@
+<?php
+declare(strict_types=1);
+namespace Neos\EventSourcing\Tests\Unit\Projection;
+
+use DG\BypassFinals;
+use Neos\EventSourcing\EventListener\Mapping\DefaultEventToListenerMappingProvider;
+use Neos\EventSourcing\EventStore\EventStoreFactory;
+use Neos\EventSourcing\Projection\ProjectionManager;
+use Neos\EventSourcing\Projection\ProjectorInterface;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
+use Neos\Flow\Reflection\ReflectionService;
+use Neos\Flow\Tests\UnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class ProjectionManagerTest extends UnitTestCase
+{
+    /**
+     * @var MockObject | ObjectManagerInterface
+     */
+    private $mockObjectManager;
+
+    /**
+     * @var MockObject | ReflectionService
+     */
+    private $mockReflectionService;
+
+    /**
+     * @var MockObject | EventStoreFactory
+     */
+    private $mockEventStoreFactory;
+
+    /**
+     * @var MockObject | DefaultEventToListenerMappingProvider
+     */
+    private $mockMappingProvider;
+
+    /**
+     * @var ProjectionManager
+     */
+    private $projectionManager;
+
+    /**
+     * @var array
+     */
+    private $projectorClassNames;
+
+    /**
+     * @return void
+     * @throws
+     * @noinspection ClassMockingCorrectnessInspection
+     */
+    public function setUp(): void
+    {
+        BypassFinals::enable();
+
+        $this->mockReflectionService = $this->createMock(ReflectionService::class);
+        $this->projectorClassNames = [
+            'acme.somepackage:projection1' => $this->getMockClass(ProjectorInterface::class, [], [], 'TestAcme' . md5((string)time()) . '1Projector'),
+            'acme.somepackage:projection2' => $this->getMockClass(ProjectorInterface::class, [], [], 'TestAcme' . md5((string)time()) . '2Projector'),
+        ];
+
+        $this->mockReflectionService->method('getAllImplementationClassNamesForInterface')->with(...ProjectorInterface::class)->willReturn([
+            $this->projectorClassNames['acme.somepackage:projection1'],
+            $this->projectorClassNames['acme.somepackage:projection2']
+        ]);
+
+        $this->mockObjectManager = $this->createMock(ObjectManagerInterface::class);
+        $this->mockObjectManager->method('get')->with(...ReflectionService::class)->willReturn($this->mockReflectionService);
+        $this->mockObjectManager->method('getPackageKeyByObjectName')->willReturn('Acme.SomePackage');
+
+        $this->mockEventStoreFactory = $this->createMock(EventStoreFactory::class);
+        $this->mockMappingProvider = $this->createMock(DefaultEventToListenerMappingProvider::class);
+
+        $this->projectionManager = new ProjectionManager($this->mockObjectManager, $this->mockEventStoreFactory, $this->mockMappingProvider);
+    }
+
+    /**
+     * @test
+     * @throws
+     */
+    public function getProjectionsReturnsDetectedProjections(): void
+    {
+        $this->projectionManager->initializeObject();
+
+        $projections = $this->projectionManager->getProjections();
+        $this->assertSame($this->projectorClassNames['acme.somepackage:projection1'], $projections[0]->getProjectorClassName());
+        $this->assertSame($this->projectorClassNames['acme.somepackage:projection2'], $projections[1]->getProjectorClassName());
+    }
+}


### PR DESCRIPTION
This change introduces a new CLI command which allows for applying
new events for a given or all projections. It's also possible to
specify the sequence number of an event up to which events should be
applied.

This command is meant to be used for debugging and other rather un-
common needs. In general, events should be applied by other means,
for example through the `CatchUpEventListenerJob`.

Resolves #270