### PR TITLE
BUGFIX: Fix unit tests

### DIFF
--- a/Tests/Unit/EventListener/EventListenerInvokerTest.php
+++ b/Tests/Unit/EventListener/EventListenerInvokerTest.php
@@ -12,8 +12,6 @@ use Neos\EventSourcing\EventListener\Exception\EventCouldNotBeAppliedException;
 use Neos\EventSourcing\EventStore\EventNormalizer;
 use Neos\EventSourcing\EventStore\EventStore;
 use Neos\EventSourcing\EventStore\EventStream;
-use Neos\EventSourcing\EventStore\EventStreamIteratorInterface;
-use Neos\EventSourcing\EventStore\RawEvent;
 use Neos\EventSourcing\EventStore\Storage\InMemory\InMemoryStreamIterator;
 use Neos\EventSourcing\EventStore\StreamAwareEventListenerInterface;
 use Neos\EventSourcing\EventStore\StreamName;
@@ -163,7 +161,7 @@ class EventListenerInvokerTest extends UnitTestCase
      */
     public function replaySetsHighestAppliedSequenceNumberToMinusOneAndCallsCatchup(): void
     {
-        $this->mockAppliedEventsStorage->expects($this->once())->method('saveHighestAppliedSequenceNumber')->with(...-1);
+        $this->mockAppliedEventsStorage->expects($this->once())->method('saveHighestAppliedSequenceNumber')->with(-1);
 
         $eventListenerInvokerPartialMock = $this->createPartialMock(EventListenerInvoker::class, ['catchUp']);
         $eventListenerInvokerPartialMock->__construct($this->mockEventStore, $this->mockEventListener, $this->mockConnection);

--- a/Tests/Unit/EventStore/Storage/InMemory/InMemoryStreamIteratorTest.php
+++ b/Tests/Unit/EventStore/Storage/InMemory/InMemoryStreamIteratorTest.php
@@ -13,10 +13,7 @@ class InMemoryStreamIteratorTest extends UnitTestCase
      */
     private $iterator;
 
-    /**
-     * @throws
-     */
-    public function setUp()
+    public function setUp(): void
     {
         $this->iterator = new InMemoryStreamIterator();
         $this->iterator->setEventRecords([
@@ -45,7 +42,6 @@ class InMemoryStreamIteratorTest extends UnitTestCase
 
     /**
      * @test
-     * @throws
      */
     public function setEventRecordsRejectsInvalidDate(): void
     {
@@ -69,7 +65,6 @@ class InMemoryStreamIteratorTest extends UnitTestCase
 
     /**
      * @test
-     * @throws
      */
     public function canSetEventRecordsAndGetRawEvents(): void
     {
@@ -82,7 +77,6 @@ class InMemoryStreamIteratorTest extends UnitTestCase
 
     /**
      * @test
-     * @throws
      */
     public function providesIteratorFunctions(): void
     {


### PR DESCRIPTION
* Add `setUp` return type hint to fix compatibilty with PhpUnit 9+
* Fix "Only arrays and Traversables can be unpacked" error with PHP 7.3