### PR TITLE
BUGFIX: Trigger publishing queue only once per eventtype/listener com…

### DIFF
--- a/Classes/EventPublisher/JobQueueEventPublisher.php
+++ b/Classes/EventPublisher/JobQueueEventPublisher.php
@@ -89,6 +89,7 @@ final class JobQueueEventPublisher implements EventPublisherInterface
             if (isset($processedEventClassNames[$eventClassName])) {
                 continue;
             }
+            $processedEventClassNames[$eventClassName] = true;
             foreach ($this->mappings as $mapping) {
                 if ($mapping->getEventClassName() !== $eventClassName) {
                     continue;


### PR DESCRIPTION
…bination

Adjusts `JobQueueEventPublisher::publish()` so that it only processes each event type once.
This is merely an optimization. The end result is the same.

Fixes: #283