### PR TITLE
BUGFIX: Clear $pendingEvents when invoking DeferEventPublisher

### DIFF
--- a/Classes/EventPublisher/DeferEventPublisher.php
+++ b/Classes/EventPublisher/DeferEventPublisher.php
@@ -64,6 +64,7 @@ final class DeferEventPublisher implements EventPublisherInterface
     {
         if (!$this->pendingEvents->isEmpty()) {
             $this->wrappedEventPublisher->publish($this->pendingEvents);
+            $this->pendingEvents = DomainEvents::createEmpty();
         }
     }
 

--- a/Tests/Unit/EventPublisher/DeferEventPublisherTest.php
+++ b/Tests/Unit/EventPublisher/DeferEventPublisherTest.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+namespace Neos\EventSourcing\Tests\Unit\EventPublisher;
+
+use Neos\EventSourcing\Event\DomainEventInterface;
+use Neos\EventSourcing\Event\DomainEvents;
+use Neos\EventSourcing\EventPublisher\DeferEventPublisher;
+use Neos\EventSourcing\EventPublisher\EventPublisherInterface;
+use Neos\Flow\Tests\UnitTestCase;
+
+class DeferEventPublisherTest extends UnitTestCase
+{
+
+    /**
+     * @test
+     */
+    public function withoutPendingEventsTheWrappedEventPublisherIsNotCalled(): void
+    {
+        $mockPublisher = self::getMockBuilder(EventPublisherInterface::class)->getMock();
+
+        $publisher = DeferEventPublisher::forPublisher(
+            $mockPublisher
+        );
+
+        $mockPublisher
+            ->expects(self::never())
+            ->method('publish');
+
+        $publisher->publish(DomainEvents::createEmpty());
+        $publisher->invoke();
+    }
+
+    /**
+     * @test
+     */
+    public function pendingEventsAreClearedAfterInvoke(): void
+    {
+        $mockPublisher = self::getMockBuilder(EventPublisherInterface::class)->getMock();
+        $eventA = self::getMockBuilder(DomainEventInterface::class)->getMock();
+        $eventB = self::getMockBuilder(DomainEventInterface::class)->getMock();
+
+        $publisher = DeferEventPublisher::forPublisher(
+            $mockPublisher
+        );
+
+        $mockPublisher
+            ->expects(self::exactly(2))
+            ->method('publish')
+            ->withConsecutive(
+                [DomainEvents::withSingleEvent($eventA)],
+                [DomainEvents::withSingleEvent($eventB)]
+            );
+
+        $publisher->publish(DomainEvents::withSingleEvent($eventA));
+        $publisher->invoke();
+
+        $publisher->publish(DomainEvents::withSingleEvent($eventB));
+        $publisher->invoke();
+    }
+
+}


### PR DESCRIPTION
Previously, consecutive calls to "invoke()" would publish old
events again as the $pendingEvents were never reset.