### PR TITLE
BUGFIX: Lock events table before committing

### DIFF
--- a/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
+++ b/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
@@ -15,6 +15,7 @@ namespace Neos\EventSourcing\EventStore\Storage\Doctrine;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ConnectionException;
 use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception\DeadlockException;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Schema;
@@ -33,6 +34,7 @@ use Neos\EventSourcing\EventStore\Storage\EventStorageInterface;
 use Neos\EventSourcing\EventStore\StreamName;
 use Neos\EventSourcing\EventStore\WritableEvent;
 use Neos\EventSourcing\EventStore\WritableEvents;
+use Throwable;
 
 /**
  * Database event storage adapter
@@ -123,6 +125,18 @@ class DoctrineEventStorage implements EventStorageInterface
         $retryWaitInterval = 0.005;
         $maxRetryAttempts = 8;
         $retryAttempt = 0;
+
+        $rollback = function (Throwable $previous) use (&$retryAttempt, $maxRetryAttempts, &$retryWaitInterval) {
+            if ($retryAttempt >= $maxRetryAttempts) {
+                $this->connection->rollBack();
+                throw new ConcurrencyException(sprintf('Failed after %d retry attempts', $retryAttempt), 1573817175, $previous);
+            }
+            usleep((int)($retryWaitInterval * 1E6));
+            $retryAttempt ++;
+            $retryWaitInterval *= 2;
+            $this->connection->rollBack();
+        };
+
         while (true) {
             $this->reconnectDatabaseConnection();
             if ($this->connection->getTransactionNestingLevel() > 0) {
@@ -130,6 +144,10 @@ class DoctrineEventStorage implements EventStorageInterface
             }
             $this->connection->beginTransaction();
             try {
+                # `SELECT FOR UPDATE` write-locks affected data, `SELECT MAX() FOR UPDATE` write-locks the table.
+                # This should be "LOCK TABLE" but "LOCK TABLE" doesn't play nicely with transactions.
+                $this->connection->query('SELECT MAX(sequencenumber) FROM ' . $this->eventTableName . ' FOR UPDATE')->fetchAll();
+
                 $actualVersion = $this->getStreamVersion($streamName);
                 $this->verifyExpectedVersion($actualVersion, $expectedVersion);
                 foreach ($events as $event) {
@@ -137,14 +155,10 @@ class DoctrineEventStorage implements EventStorageInterface
                     $this->commitEvent($streamName, $event, $actualVersion);
                 }
             } catch (UniqueConstraintViolationException $exception) {
-                if ($retryAttempt >= $maxRetryAttempts) {
-                    $this->connection->rollBack();
-                    throw new ConcurrencyException(sprintf('Failed after %d retry attempts', $retryAttempt), 1573817175, $exception);
-                }
-                usleep((int)($retryWaitInterval * 1E6));
-                $retryAttempt++;
-                $retryWaitInterval *= 2;
-                $this->connection->rollBack();
+                $rollback($exception);
+                continue;
+            } catch (DeadlockException $exception) {
+                $rollback($exception);
                 continue;
             } catch (DBALException | ConcurrencyException $exception) {
                 $this->connection->rollBack();
@@ -159,7 +173,7 @@ class DoctrineEventStorage implements EventStorageInterface
      * @param StreamName $streamName
      * @param WritableEvent $event
      * @param int $version
-     * @throws DBALException | UniqueConstraintViolationException
+     * @throws DBALException | UniqueConstraintViolationException | DeadlockException
      */
     private function commitEvent(StreamName $streamName, WritableEvent $event, int $version): void
     {


### PR DESCRIPTION
There are situations where two processes try to write data to the event
store simultaneously.

    |sequence number|event                 |source        |
    |1              |do first thing        |first process |
    |2              |do second thing       |first process |
    |3              |do something different|second process|
    |4              |do third thing        |first process |
    |5              |do fourth thing       |first process |

The second process starts second but will finish first.

So there is a point in time the event store looks like this:

    |sequence number|event                 |source        |
    |3              |do something different|second process|

- If now a listener starts catching up, it will be remered as
  highest applied sequence number = 3.
- As soon as the first process finishes, another catch up happens starting
  at sequence number 4.
- So in this very situation, sequence numbers 1 and 2 are recorded and
  even recorded in the right order but never played.