### PR TITLE
Guaranty order of sequencenumber

### DIFF
--- a/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
+++ b/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
@@ -85,7 +85,8 @@ class DoctrineEventStorage implements EventStorageInterface
         $this->reconnectDatabaseConnection();
         $query = $this->connection->createQueryBuilder()
             ->select('*')
-            ->from($this->eventTableName);
+            ->from($this->eventTableName)
+            ->orderBy('sequencenumber', 'ASC');
 
         if (!$streamName->isVirtualStream()) {
             $query->andWhere('stream = :streamName');


### PR DESCRIPTION
When not setting the order by the sorting of the query is not always the primary key depending on the order in the index.
For me as simple category stream query retuned the following order and thats why the projector not getting all events in the correct order:
|sequencenumber|
| ------------- |
|83            |
|63            |
|1018          |
|209           |
|161           |
|1             |
|71            |
|623           |
|59            |
|67            |
|922           |
|178           |
|225           |