### PR TITLE
BUGFIX: Avoid transaction when setting up event store table

### DIFF
--- a/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
+++ b/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
@@ -304,16 +304,9 @@ class DoctrineEventStorage implements EventStorageInterface
             $result->addNotice(new Notice('Table schema is up to date, no migration required'));
             return $result;
         }
-        $this->connection->beginTransaction();
-        try {
-            foreach ($statements as $statement) {
-                $result->addNotice(new Notice('<info>++</info> %s', null, [$statement]));
-                $this->connection->exec($statement);
-            }
-            $this->connection->commit();
-        } catch (\Throwable $exception) {
-            $this->connection->rollBack();
-            throw $exception;
+        foreach ($statements as $statement) {
+            $result->addNotice(new Notice('<info>++</info> %s', null, [$statement]));
+            $this->connection->exec($statement);
         }
         return $result;
     }


### PR DESCRIPTION
Some database engines don't support DDL statements (such as `CREATE TABLE`
or `ALTER TABLE`) within transactions.

The issue existed before PHP 8 but is now made visible by e.g. PDO, which now produces an
```
There is no active transaction
```
error when trying to setup an event store table via `./flow eventstore:setup`.

See https://github.com/doctrine/migrations/blob/3.2.x/docs/en/explanation/implicit-commits.rst

Fixes: #291