### PR TITLE
Fix fatal error in projection:list command

### DIFF
--- a/Classes/Command/ProjectionCommandController.php
+++ b/Classes/Command/ProjectionCommandController.php
@@ -342,6 +342,6 @@ class ProjectionCommandController extends CommandController
         if ($length <= $maximumCharacters) {
             return $text;
         }
-        return substr_replace($text, '...', ($maximumCharacters - 3) / 2, $length - $maximumCharacters + 3);
+        return substr_replace($text, '...', (int)(($maximumCharacters - 3) / 2), $length - $maximumCharacters + 3);
     }
 }


### PR DESCRIPTION
Depending on the length of the name of projections, the following
error could occur:

`substr_replace(): Argument #3 ($offset) must be of type array|int,
float given`