### PR TITLE
BUGFIX: Refactor DoctrineAdapterTest setup to avoid failure with defa…

### DIFF
--- a/Tests/Functional/EventListener/AppliedEventsStorage/DoctrineAdapterTest.php
+++ b/Tests/Functional/EventListener/AppliedEventsStorage/DoctrineAdapterTest.php
@@ -26,15 +26,15 @@ class DoctrineAdapterTest extends FunctionalTestCase
 
     public function setUp(): void
     {
-        parent::setUp();
         /** @var EntityManagerInterface $entityManager */
-        $entityManager = $this->objectManager->get(EntityManagerInterface::class);
+        $entityManager = self::$bootstrap->getObjectManager()->get(EntityManagerInterface::class);
         $dbal1 = $entityManager->getConnection();
 
         $platform = $dbal1->getDatabasePlatform()->getName();
         if ($platform !== 'mysql' && $platform !== 'postgresql') {
             self::markTestSkipped(sprintf('DB platform "%s" is not supported', $platform));
         }
+        parent::setUp();
 
         $this->adapter1 = new DoctrineAppliedEventsStorage($dbal1, 'someEventListenerIdentifier');
 


### PR DESCRIPTION
…ult db setup

swaps the order of the `parent::setUp()` call with the db platform check in order
to prevent the tests from failing with

    1 table neos_contentrepository_migration_domain_model_migrationstatus already exists'

when executed with the default database setup (sqlite in memory)