### PR TITLE
TASK: Use "static" return type where needed

### DIFF
--- a/Classes/AbstractEventSourcedAggregateRoot.php
+++ b/Classes/AbstractEventSourcedAggregateRoot.php
@@ -49,7 +49,7 @@ abstract class AbstractEventSourcedAggregateRoot implements EventRecordingInterf
         return $this->reconstitutionVersion;
     }
 
-    final public static function reconstituteFromEventStream(EventStream $stream): self
+    final public static function reconstituteFromEventStream(EventStream $stream): static
     {
         $instance = new static();
         $lastAppliedEventVersion = -1;

--- a/Classes/Event/DecoratedEvent.php
+++ b/Classes/Event/DecoratedEvent.php
@@ -44,38 +44,38 @@ final class DecoratedEvent implements DomainEventInterface
         $this->identifier = $identifier;
     }
 
-    public static function addMetadata(DomainEventInterface $event, array $metadata): self
+    public static function addMetadata(DomainEventInterface $event, array $metadata): DecoratedEvent
     {
         $identifier = null;
-        if ($event instanceof self) {
+        if ($event instanceof DecoratedEvent) {
             $metadata = Arrays::arrayMergeRecursiveOverrule($event->metadata, $metadata);
             $identifier = $event->identifier;
             $event = $event->getWrappedEvent();
         }
-        return new self($event, $metadata, $identifier);
+        return new DecoratedEvent($event, $metadata, $identifier);
     }
 
-    public static function addCausationIdentifier(DomainEventInterface $event, string $causationIdentifier): self
+    public static function addCausationIdentifier(DomainEventInterface $event, string $causationIdentifier): DecoratedEvent
     {
-        self::validateIdentifier($causationIdentifier);
-        return self::addMetadata($event, ['causationIdentifier' => $causationIdentifier]);
+        DecoratedEvent::validateIdentifier($causationIdentifier);
+        return DecoratedEvent::addMetadata($event, ['causationIdentifier' => $causationIdentifier]);
     }
 
-    public static function addCorrelationIdentifier(DomainEventInterface $event, string $correlationIdentifier): self
+    public static function addCorrelationIdentifier(DomainEventInterface $event, string $correlationIdentifier): DecoratedEvent
     {
-        self::validateIdentifier($correlationIdentifier);
-        return self::addMetadata($event, ['correlationIdentifier' => $correlationIdentifier]);
+        DecoratedEvent::validateIdentifier($correlationIdentifier);
+        return DecoratedEvent::addMetadata($event, ['correlationIdentifier' => $correlationIdentifier]);
     }
 
-    public static function addIdentifier(DomainEventInterface $event, string $identifier): self
+    public static function addIdentifier(DomainEventInterface $event, string $identifier): DecoratedEvent
     {
-        self::validateIdentifier($identifier);
+        DecoratedEvent::validateIdentifier($identifier);
         $metadata = [];
-        if ($event instanceof self) {
+        if ($event instanceof DecoratedEvent) {
             $metadata = $event->metadata;
             $event = $event->getWrappedEvent();
         }
-        return new self($event, $metadata, $identifier);
+        return new DecoratedEvent($event, $metadata, $identifier);
     }
 
     public function getWrappedEvent(): DomainEventInterface

--- a/Classes/Event/DomainEvents.php
+++ b/Classes/Event/DomainEvents.php
@@ -41,42 +41,42 @@ final class DomainEvents implements \IteratorAggregate, \Countable
         $this->iterator = new \ArrayIterator($events);
     }
 
-    public static function createEmpty(): self
+    public static function createEmpty(): DomainEvents
     {
-        return new self([]);
+        return new DomainEvents([]);
     }
 
     /**
      * @param array<string|int,DomainEventInterface> $events
      */
-    public static function fromArray(array $events): self
+    public static function fromArray(array $events): DomainEvents
     {
         foreach ($events as $event) {
             if (!$event instanceof DomainEventInterface) {
                 throw new \InvalidArgumentException(sprintf('Only instances of EventInterface are allowed, given: %s', \is_object($event) ? \get_class($event) : \gettype($event)), 1540311882);
             }
         }
-        return new self(array_values($events));
+        return new DomainEvents(array_values($events));
     }
 
-    public static function withSingleEvent(DomainEventInterface $event): self
+    public static function withSingleEvent(DomainEventInterface $event): DomainEvents
     {
-        return new self([$event]);
+        return new DomainEvents([$event]);
     }
 
-    public function appendEvent(DomainEventInterface $event): self
+    public function appendEvent(DomainEventInterface $event): DomainEvents
     {
         $events = $this->events;
         $events[] = $event;
 
-        return new self($events);
+        return new DomainEvents($events);
     }
 
-    public function appendEvents(self $other): self
+    public function appendEvents(DomainEvents $other): DomainEvents
     {
         $events = array_merge($this->events, $other->events);
 
-        return new self($events);
+        return new DomainEvents($events);
     }
 
     public function getFirst(): DomainEventInterface
@@ -96,16 +96,16 @@ final class DomainEvents implements \IteratorAggregate, \Countable
         return $this->iterator;
     }
 
-    public function map(\Closure $processor): self
+    public function map(\Closure $processor): DomainEvents
     {
         $convertedEvents = array_map($processor, $this->events);
-        return self::fromArray($convertedEvents);
+        return DomainEvents::fromArray($convertedEvents);
     }
 
-    public function filter(\Closure $expression): self
+    public function filter(\Closure $expression): DomainEvents
     {
         $filteredEvents = array_filter($this->events, $expression);
-        return self::fromArray($filteredEvents);
+        return DomainEvents::fromArray($filteredEvents);
     }
 
     public function isEmpty(): bool

--- a/Classes/EventListener/AppliedEventsStorage/DefaultAppliedEventsStorage.php
+++ b/Classes/EventListener/AppliedEventsStorage/DefaultAppliedEventsStorage.php
@@ -55,7 +55,7 @@ final class DefaultAppliedEventsStorage implements AppliedEventsStorageInterface
      */
     public static function forEventListener(EventListenerInterface $listener): self
     {
-        return new static(\get_class($listener));
+        return new self(\get_class($listener));
     }
 
     /**

--- a/Classes/EventListener/AppliedEventsStorage/DefaultAppliedEventsStorage.php
+++ b/Classes/EventListener/AppliedEventsStorage/DefaultAppliedEventsStorage.php
@@ -51,11 +51,11 @@ final class DefaultAppliedEventsStorage implements AppliedEventsStorageInterface
      * Creates an instance for the given EventListenerInterface
      *
      * @param EventListenerInterface $listener
-     * @return self
+     * @return DefaultAppliedEventsStorage
      */
-    public static function forEventListener(EventListenerInterface $listener): self
+    public static function forEventListener(EventListenerInterface $listener): DefaultAppliedEventsStorage
     {
-        return new self(\get_class($listener));
+        return new DefaultAppliedEventsStorage(\get_class($listener));
     }
 
     /**

--- a/Classes/EventListener/EventListenerInvoker.php
+++ b/Classes/EventListener/EventListenerInvoker.php
@@ -116,9 +116,9 @@ final class EventListenerInvoker
      * $eventListenerInvoker = (new EventListenerInvoker($eventStore, $listener, $connection))->withTransactionBatchSize(100)->catchUp();
      *
      * @param int $batchSize
-     * @return self
+     * @return EventListenerInvoker
      */
-    public function withTransactionBatchSize(int $batchSize): self
+    public function withTransactionBatchSize(int $batchSize): EventListenerInvoker
     {
         if ($batchSize < 1) {
             throw new \InvalidArgumentException('The batch size must not be smaller than 1', 1584276378);
@@ -136,9 +136,9 @@ final class EventListenerInvoker
      * $eventListenerInvoker = (new EventListenerInvoker($eventStore, $listener, $connection))->withMaximumSequenceNumber(268)->replay();
      *
      * @param int $maximumSequenceNumber
-     * @return self
+     * @return EventListenerInvoker
      */
-    public function withMaximumSequenceNumber(int $maximumSequenceNumber): self
+    public function withMaximumSequenceNumber(int $maximumSequenceNumber): EventListenerInvoker
     {
         if ($maximumSequenceNumber < 1) {
             throw new \InvalidArgumentException('The maximum sequence number must be greater than 0', 1597821711);

--- a/Classes/EventListener/Mapping/EventToListenerMapping.php
+++ b/Classes/EventListener/Mapping/EventToListenerMapping.php
@@ -43,9 +43,9 @@ final class EventToListenerMapping implements \JsonSerializable
         $this->options = $options;
     }
 
-    public static function create(string $eventClassName, string $listenerClassName, array $options): self
+    public static function create(string $eventClassName, string $listenerClassName, array $options): EventToListenerMapping
     {
-        return new self($eventClassName, $listenerClassName, $options);
+        return new EventToListenerMapping($eventClassName, $listenerClassName, $options);
     }
 
     public function getEventClassName(): string

--- a/Classes/EventListener/Mapping/EventToListenerMapping.php
+++ b/Classes/EventListener/Mapping/EventToListenerMapping.php
@@ -45,7 +45,7 @@ final class EventToListenerMapping implements \JsonSerializable
 
     public static function create(string $eventClassName, string $listenerClassName, array $options): self
     {
-        return new static($eventClassName, $listenerClassName, $options);
+        return new self($eventClassName, $listenerClassName, $options);
     }
 
     public function getEventClassName(): string

--- a/Classes/EventListener/Mapping/EventToListenerMappings.php
+++ b/Classes/EventListener/Mapping/EventToListenerMappings.php
@@ -35,12 +35,12 @@ class EventToListenerMappings implements \IteratorAggregate, \JsonSerializable
     /**
      * @return static
      */
-    public static function createEmpty(): self
+    public static function createEmpty(): static
     {
         return new static([]);
     }
 
-    public function withMapping(EventToListenerMapping $mapping): self
+    public function withMapping(EventToListenerMapping $mapping): static
     {
         $mappings = $this->mappings;
         $mappings[] = $mapping;
@@ -51,7 +51,7 @@ class EventToListenerMappings implements \IteratorAggregate, \JsonSerializable
      * @param EventToListenerMapping[] $mappings
      * @return static
      */
-    public static function fromArray(array $mappings): self
+    public static function fromArray(array $mappings): static
     {
         foreach ($mappings as $mapping) {
             if (!$mapping instanceof EventToListenerMapping) {
@@ -61,7 +61,7 @@ class EventToListenerMappings implements \IteratorAggregate, \JsonSerializable
         return new static(array_values($mappings));
     }
 
-    public function filter(\closure $callback): EventToListenerMappings
+    public function filter(\closure $callback): static
     {
         return new static(array_filter($this->mappings, $callback));
     }

--- a/Classes/EventPublisher/DeferEventPublisher.php
+++ b/Classes/EventPublisher/DeferEventPublisher.php
@@ -37,9 +37,13 @@ final class DeferEventPublisher implements EventPublisherInterface
         $this->pendingEvents = DomainEvents::createEmpty();
     }
 
+    /**
+     * @param EventPublisherInterface $eventPublisher
+     * @return self
+     */
     public static function forPublisher(EventPublisherInterface $eventPublisher): self
     {
-        return new static($eventPublisher);
+        return new self($eventPublisher);
     }
 
     /**
@@ -50,6 +54,9 @@ final class DeferEventPublisher implements EventPublisherInterface
         $this->pendingEvents = $this->pendingEvents->appendEvents($events);
     }
 
+    /**
+     * @return EventPublisherInterface
+     */
     public function getWrappedEventPublisher(): EventPublisherInterface
     {
         return $this->wrappedEventPublisher;

--- a/Classes/EventPublisher/DeferEventPublisher.php
+++ b/Classes/EventPublisher/DeferEventPublisher.php
@@ -39,11 +39,11 @@ final class DeferEventPublisher implements EventPublisherInterface
 
     /**
      * @param EventPublisherInterface $eventPublisher
-     * @return self
+     * @return DeferEventPublisher
      */
-    public static function forPublisher(EventPublisherInterface $eventPublisher): self
+    public static function forPublisher(EventPublisherInterface $eventPublisher): DeferEventPublisher
     {
-        return new self($eventPublisher);
+        return new DeferEventPublisher($eventPublisher);
     }
 
     /**

--- a/Classes/EventStore/StreamName.php
+++ b/Classes/EventStore/StreamName.php
@@ -17,7 +17,7 @@ final class StreamName
     private $value;
 
     /**
-     * @var self[]
+     * @var StreamName[]
      */
     private static $instances = [];
 
@@ -26,46 +26,46 @@ final class StreamName
         $this->value = $value;
     }
 
-    private static function constant(string $value): self
+    private static function constant(string $value): StreamName
     {
-        return self::$instances[$value] ?? self::$instances[$value] = new self($value);
+        return StreamName::$instances[$value] ?? StreamName::$instances[$value] = new StreamName($value);
     }
 
-    public static function fromString(string $value): self
+    public static function fromString(string $value): StreamName
     {
-        $value = self::trimAndValidateNotEmpty($value);
-        if (self::stringStartsWith($value, '$')) {
+        $value = StreamName::trimAndValidateNotEmpty($value);
+        if (StreamName::stringStartsWith($value, '$')) {
             throw new \InvalidArgumentException('The stream name must not start with "$"', 1540632865);
         }
-        return self::constant($value);
+        return StreamName::constant($value);
     }
 
-    public static function forCategory(string $categoryName): self
+    public static function forCategory(string $categoryName): StreamName
     {
-        $categoryName = self::trimAndValidateNotEmpty($categoryName);
-        if (self::stringStartsWith($categoryName, '$')) {
+        $categoryName = StreamName::trimAndValidateNotEmpty($categoryName);
+        if (StreamName::stringStartsWith($categoryName, '$')) {
             throw new \InvalidArgumentException('The category name must not start with "$"', 1540632884);
         }
-        return self::constant('$ce-' . $categoryName);
+        return StreamName::constant('$ce-' . $categoryName);
     }
 
-    public static function forCorrelationId(string $correlationId): self
+    public static function forCorrelationId(string $correlationId): StreamName
     {
-        $correlationId = self::trimAndValidateNotEmpty($correlationId);
-        if (self::stringStartsWith($correlationId, '$')) {
+        $correlationId = StreamName::trimAndValidateNotEmpty($correlationId);
+        if (StreamName::stringStartsWith($correlationId, '$')) {
             throw new \InvalidArgumentException('The correlation identifier must not start with "$"', 1540899066);
         }
-        return self::constant('$correlation-' . $correlationId);
+        return StreamName::constant('$correlation-' . $correlationId);
     }
 
-    public static function all(): self
+    public static function all(): StreamName
     {
-        return self::constant('$all');
+        return StreamName::constant('$all');
     }
 
     public function isVirtualStream(): bool
     {
-        return self::stringStartsWith($this->value, '$');
+        return StreamName::stringStartsWith($this->value, '$');
     }
 
     public function isAllStream(): bool
@@ -75,12 +75,12 @@ final class StreamName
 
     public function isCategoryStream(): bool
     {
-        return self::stringStartsWith($this->value, '$ce-');
+        return StreamName::stringStartsWith($this->value, '$ce-');
     }
 
     public function isCorrelationIdStream(): bool
     {
-        return self::stringStartsWith($this->value, '$correlation-');
+        return StreamName::stringStartsWith($this->value, '$correlation-');
     }
 
     public function getCategoryName(): string

--- a/Classes/EventStore/WritableEvents.php
+++ b/Classes/EventStore/WritableEvents.php
@@ -37,14 +37,14 @@ final class WritableEvents implements \IteratorAggregate, \Countable
                 throw new \InvalidArgumentException(sprintf('Only instances of WritableEvent are allowed, given: %s', \is_object($event) ? \get_class($event) : \gettype($event)), 1540316594);
             }
         }
-        return new static(array_values($events));
+        return new self(array_values($events));
     }
 
     public function append(WritableEvent $event): self
     {
         $events = $this->events;
         $events[] = $event;
-        return new static($events);
+        return new self($events);
     }
 
     /**

--- a/Classes/EventStore/WritableEvents.php
+++ b/Classes/EventStore/WritableEvents.php
@@ -30,21 +30,21 @@ final class WritableEvents implements \IteratorAggregate, \Countable
         $this->events = $events;
     }
 
-    public static function fromArray(array $events): self
+    public static function fromArray(array $events): WritableEvents
     {
         foreach ($events as $event) {
             if (!$event instanceof WritableEvent) {
                 throw new \InvalidArgumentException(sprintf('Only instances of WritableEvent are allowed, given: %s', \is_object($event) ? \get_class($event) : \gettype($event)), 1540316594);
             }
         }
-        return new self(array_values($events));
+        return new WritableEvents(array_values($events));
     }
 
-    public function append(WritableEvent $event): self
+    public function append(WritableEvent $event): WritableEvents
     {
         $events = $this->events;
         $events[] = $event;
-        return new self($events);
+        return new WritableEvents($events);
     }
 
     /**

--- a/Glossary.md
+++ b/Glossary.md
@@ -60,7 +60,7 @@ final class InvoiceNumbering extends AbstractEventSourcedAggregateRoot
      */
     private $highestAssignedInvoiceNumber = 0;
 
-    public static function create(): self
+    public static function create(): static
     {
         return new static();
     }

--- a/Readme.md
+++ b/Readme.md
@@ -377,9 +377,9 @@ final class SomeAggregate extends AbstractEventSourcedAggregateRoot
      */
     private $id;
 
-    public static function create(SomeAggregateId $id): self
+    public static function create(SomeAggregateId $id): SomeAggregate
     {
-        $instance = new static();
+        $instance = new SomeAggregate();
         // This method will only be invoked once. Upon reconstitution only the when*() methods are called.
         // So we must never change the instance state directly (i.e. $instance->id = $id) but use events:
         $instance->recordThat(new SomeAggregateWasCreated($id));

--- a/Tests/Unit/EventStore/Fixture/ArrayValueObject.php
+++ b/Tests/Unit/EventStore/Fixture/ArrayValueObject.php
@@ -12,12 +12,12 @@ final class ArrayValueObject implements \JsonSerializable
         $this->value = $value;
     }
 
-    public static function fromArray(array $value): self
+    public static function fromArray(array $value): ArrayValueObject
     {
-        return new self($value);
+        return new ArrayValueObject($value);
     }
 
-    public function equals(self $other): bool
+    public function equals(ArrayValueObject $other): bool
     {
         return $other->value === $this->value;
     }

--- a/Tests/Unit/EventStore/Fixture/BooleanValueObject.php
+++ b/Tests/Unit/EventStore/Fixture/BooleanValueObject.php
@@ -12,12 +12,12 @@ final class BooleanValueObject implements \JsonSerializable
         $this->value = $value;
     }
 
-    public static function fromBoolean(bool $value): self
+    public static function fromBoolean(bool $value): BooleanValueObject
     {
-        return new self($value);
+        return new BooleanValueObject($value);
     }
 
-    public function equals(self $other): bool
+    public function equals(BooleanValueObject $other): bool
     {
         return $other->value === $this->value;
     }

--- a/Tutorial.md
+++ b/Tutorial.md
@@ -514,7 +514,7 @@ final class Inbox
      * @param string $userId
      * @return static
      */
-    public static function forUser(string $userId): self
+    public static function forUser(string $userId): static
     {
         return new static($userId);
     }


### PR DESCRIPTION
This change corrects return types to "static" where late static
binding is used and corrects `new static` to `new self` in classes
declared as `final`.

Resolves #309