### PR TITLE
This change corrects return types to "static" where late static

### DIFF
--- a/Classes/AbstractEventSourcedAggregateRoot.php
+++ b/Classes/AbstractEventSourcedAggregateRoot.php
@@ -49,7 +49,7 @@ abstract class AbstractEventSourcedAggregateRoot implements EventRecordingInterf
         return $this->reconstitutionVersion;
     }
 
-    final public static function reconstituteFromEventStream(EventStream $stream): self
+    final public static function reconstituteFromEventStream(EventStream $stream): static
     {
         $instance = new static();
         $lastAppliedEventVersion = -1;

--- a/Classes/Event/EventTypeResolver.php
+++ b/Classes/Event/EventTypeResolver.php
@@ -56,7 +56,7 @@ final class EventTypeResolver implements EventTypeResolverInterface
      */
     public function initializeObject(): void
     {
-        $this->mapping = static::eventTypeMapping($this->objectManager);
+        $this->mapping = self::eventTypeMapping($this->objectManager);
         $this->reversedMapping = array_flip($this->mapping);
     }
 

--- a/Classes/EventListener/AppliedEventsStorage/DefaultAppliedEventsStorage.php
+++ b/Classes/EventListener/AppliedEventsStorage/DefaultAppliedEventsStorage.php
@@ -55,7 +55,7 @@ final class DefaultAppliedEventsStorage implements AppliedEventsStorageInterface
      */
     public static function forEventListener(EventListenerInterface $listener): self
     {
-        return new static(\get_class($listener));
+        return new DefaultAppliedEventsStorage(\get_class($listener));
     }
 
     /**

--- a/Classes/EventListener/Mapping/EventToListenerMapping.php
+++ b/Classes/EventListener/Mapping/EventToListenerMapping.php
@@ -45,7 +45,7 @@ final class EventToListenerMapping implements \JsonSerializable
 
     public static function create(string $eventClassName, string $listenerClassName, array $options): self
     {
-        return new static($eventClassName, $listenerClassName, $options);
+        return new self($eventClassName, $listenerClassName, $options);
     }
 
     public function getEventClassName(): string

--- a/Classes/EventPublisher/DeferEventPublisher.php
+++ b/Classes/EventPublisher/DeferEventPublisher.php
@@ -39,7 +39,7 @@ final class DeferEventPublisher implements EventPublisherInterface
 
     public static function forPublisher(EventPublisherInterface $eventPublisher): self
     {
-        return new static($eventPublisher);
+        return new DeferEventPublisher($eventPublisher);
     }
 
     /**

--- a/Classes/EventStore/WritableEvents.php
+++ b/Classes/EventStore/WritableEvents.php
@@ -37,14 +37,14 @@ final class WritableEvents implements \IteratorAggregate, \Countable
                 throw new \InvalidArgumentException(sprintf('Only instances of WritableEvent are allowed, given: %s', \is_object($event) ? \get_class($event) : \gettype($event)), 1540316594);
             }
         }
-        return new static(array_values($events));
+        return new self(array_values($events));
     }
 
     public function append(WritableEvent $event): self
     {
         $events = $this->events;
         $events[] = $event;
-        return new static($events);
+        return new self($events);
     }
 
     /**


### PR DESCRIPTION
binding is used and corrects `new static` to `new self` in classes
declared as `final`.

*Exceptions:* For `DeferEventPublisher` and `DefaultAppliedEventsStorage` the
class name itself is used in order to prevent IDEs to complain about the use
of `static` in a final class. Those classes currently rely on Flow object
management so `self` refers to the proxy class

Resolves #309