### PR TITLE
FEATURE: Add normalize support for ValueObjectNormalizer

### DIFF
--- a/Tests/Unit/EventStore/Normalizer/ValueObjectNormalizerTest.php
+++ b/Tests/Unit/EventStore/Normalizer/ValueObjectNormalizerTest.php
@@ -66,4 +66,32 @@ class ValueObjectNormalizerTest extends UnitTestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->valueObjectNormalizer->denormalize(['some' => 'array'], Fixture\InvalidArrayBasedValueObject::class);
     }
+
+    /**
+     * @test
+     * @dataProvider provideNormalizationSourceDataAndValueObject
+     */
+    public function supportsNormalizationTests($data, $object): void
+    {
+        $this->assertTrue(
+            $this->valueObjectNormalizer->supportsNormalization($object, null)
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider provideNormalizationSourceDataAndValueObject
+     */
+    public function normalizeTests($data, $object): void
+    {
+        $this->assertEquals(
+            $data,
+            $this->valueObjectNormalizer->normalize($object)
+        );
+    }
+
+    public function provideNormalizationSourceDataAndValueObject()
+    {
+        yield 'string' => ['stringObject', Fixture\StringBasedValueObject::fromString('stringObject')];
+    }
 }


### PR DESCRIPTION
The ValueObjectNormalizer could be a Normalizer that also takes care of normalizing values. If they are `Stringable` (or has the `__toString` method) or `JsonSerializable`, the value can be normalized, before committing the event.

This gives values in the eventstore such as

```
    "userIdentifier": "e250806e-b32f-4ff3-b389-682068c8688b"
```

when `Stringable`/`__toString` method

and

```
    "userIdentifier": {"identifier": "e250806e-b32f-4ff3-b389-682068c8688b"}
```

when `JsonSerializable`.

The denormalize method, looks for the corresponding `from<type>` constructor method, so denormalizing is untouched.