### PR TITLE
Speed up catchUp() and replay()

### DIFF
--- a/Classes/EventListener/EventListenerInvoker.php
+++ b/Classes/EventListener/EventListenerInvoker.php
@@ -169,6 +169,7 @@ final class EventListenerInvoker
         $streamName = $this->eventListener instanceof StreamAwareEventListenerInterface ? $this->eventListener::listensToStream() : StreamName::all();
         $eventStream = $this->eventStore->load($streamName, $highestAppliedSequenceNumber + 1);
         $appliedEventsCounter = 0;
+        $sequenceNumber = 0;
 
         foreach ($eventStream as $eventEnvelope) {
             $sequenceNumber = $eventEnvelope->getRawEvent()->getSequenceNumber();
@@ -181,23 +182,27 @@ final class EventListenerInvoker
                 break;
             }
             try {
-                $this->applyEvent($eventEnvelope);
+                $eventWasApplied = $this->applyEvent($eventEnvelope);
             } catch (EventCouldNotBeAppliedException $exception) {
                 $appliedEventsStorage->releaseHighestAppliedSequenceNumber();
                 throw $exception;
             }
-            $appliedEventsCounter ++;
-            $appliedEventsStorage->saveHighestAppliedSequenceNumber($eventEnvelope->getRawEvent()->getSequenceNumber());
-            if ($this->transactionBatchSize === 1 || $appliedEventsCounter % $this->transactionBatchSize === 0) {
-                $appliedEventsStorage->releaseHighestAppliedSequenceNumber();
-                $highestAppliedSequenceNumber = $appliedEventsStorage->reserveHighestAppliedEventSequenceNumber();
-            } else {
-                $highestAppliedSequenceNumber = $sequenceNumber;
+            if ($eventWasApplied) {
+                $appliedEventsCounter ++;
+                $appliedEventsStorage->saveHighestAppliedSequenceNumber($sequenceNumber);
+                if ($this->transactionBatchSize === 1 || $appliedEventsCounter % $this->transactionBatchSize === 0) {
+                    $appliedEventsStorage->releaseHighestAppliedSequenceNumber();
+                    $highestAppliedSequenceNumber = $appliedEventsStorage->reserveHighestAppliedEventSequenceNumber();
+                } else {
+                    $highestAppliedSequenceNumber = $sequenceNumber;
+                }
             }
             foreach ($this->progressCallbacks as $callback) {
                 $callback($eventEnvelope);
             }
         }
+
+        $appliedEventsStorage->saveHighestAppliedSequenceNumber($sequenceNumber);
         $appliedEventsStorage->releaseHighestAppliedSequenceNumber();
 
         if ($this->eventListener instanceof AfterCatchUpInterface) {
@@ -207,19 +212,17 @@ final class EventListenerInvoker
 
     /**
      * @param EventEnvelope $eventEnvelope
+     * @return bool If the event was applied, false if no matching listener method existed
      * @throws EventCouldNotBeAppliedException
      */
-    private function applyEvent(EventEnvelope $eventEnvelope): void
+    private function applyEvent(EventEnvelope $eventEnvelope): bool
     {
         $event = $eventEnvelope->getDomainEvent();
         $rawEvent = $eventEnvelope->getRawEvent();
-        try {
-            $listenerMethodName = 'when' . (new \ReflectionClass($event))->getShortName();
-        } catch (\ReflectionException $exception) {
-            throw new \RuntimeException(sprintf('Could not extract listener method name for listener %s and event %s', \get_class($this->eventListener), \get_class($event)), 1541003718, $exception);
-        }
+        $eventClassName = get_class($event);
+        $listenerMethodName = 'when' . substr($eventClassName, strrpos($eventClassName, '\\') + 1);
         if (!method_exists($this->eventListener, $listenerMethodName)) {
-            return;
+            return false;
         }
         if ($this->eventListener instanceof BeforeInvokeInterface) {
             $this->eventListener->beforeInvoke($eventEnvelope);
@@ -232,6 +235,7 @@ final class EventListenerInvoker
         if ($this->eventListener instanceof AfterInvokeInterface) {
             $this->eventListener->afterInvoke($eventEnvelope);
         }
+        return true;
     }
 
     /**

--- a/Classes/EventListener/EventListenerInvoker.php
+++ b/Classes/EventListener/EventListenerInvoker.php
@@ -202,7 +202,9 @@ final class EventListenerInvoker
             }
         }
 
-        $appliedEventsStorage->saveHighestAppliedSequenceNumber($sequenceNumber);
+        if ($sequenceNumber > 0) {
+            $appliedEventsStorage->saveHighestAppliedSequenceNumber($sequenceNumber);
+        }
         $appliedEventsStorage->releaseHighestAppliedSequenceNumber();
 
         if ($this->eventListener instanceof AfterCatchUpInterface) {


### PR DESCRIPTION
While catching up or replaying a projection, a transaction for the highest applied event sequence number is only closed when an event was actually applied or the catch-up-process is done. This speeds up the process dramatically for event stores containing hundreds of thousands of events.

Two examples:

1) Event store with 2.000.000 events. Only 3500 are relevant for the projection in question. Replaying the projection takes

- 6 minutes 22 seconds without the patch
- 0 minutes 50 seconds with the patch

2) Event listener lags 50.000 events behind. Only 1 new relevant event for the projection. Catching up takes

- 87100 milliseconds without the patch
-  1200 milliseconds with the patch

Resolves #316